### PR TITLE
Add Metadata to Documentation Markdown Files

### DIFF
--- a/docs/AI/Ai.md
+++ b/docs/AI/Ai.md
@@ -1,3 +1,45 @@
+---
+title: Introduction to Artificial Intelligence
+
+description: A foundational overview of Artificial Intelligence, exploring its history, core concepts, major domains, and its transformative impact across industries and everyday life.
+
+id: introduction-to-artificial-intelligence
+
+tags:
+- Artificial Intelligence  
+- AI  
+- Machine Learning  
+- Deep Learning  
+- Neural Networks  
+- Computer Vision  
+- Natural Language Processing  
+- AI Ethics  
+- Automation  
+- Robotics  
+- Supervised Learning  
+- Unsupervised Learning  
+- AI Applications  
+- Intelligent Systems  
+- Data Science
+
+keywords:
+- Introduction to AI  
+- History of Artificial Intelligence  
+- Machine Learning Basics  
+- Deep Learning Concepts  
+- AI in Healthcare  
+- Natural Language Processing  
+- AI for Beginners  
+- Future of AI  
+- AI Tools and Techniques  
+- Neural Networks Explained  
+- Robotics and Automation  
+- Supervised vs Unsupervised Learning  
+- AI Ethics and Responsibility  
+- Real-world AI Use Cases  
+- Data-Driven Intelligence
+
+---
 # 🎓 AI Applications
 
 Welcome to the **AI Applications** section! Choose from the categories below to explore how artificial intelligence is transforming various fields and learn about its powerful applications:

--- a/docs/DSA/Linear_DSA.md
+++ b/docs/DSA/Linear_DSA.md
@@ -1,1 +1,7 @@
+---
+tags: [Data Structures, DSA, Linear Data Structures, Arrays, Linked Lists, Stacks, Queues]
+keywords: [data structures, algorithms, introduction to DSA, coding basics, algorithm fundamentals, time complexity, space complexity, programming concepts]
+description: >
+  This document covers the foundational concepts of Linear Data Structures in Data Structures and Algorithms (DSA), including Arrays, Linked Lists, Stacks, and Queues. It explains their operations, use cases, and implementation details.
+---
 # Comming Soon

--- a/docs/DSA/Time_and_space.md
+++ b/docs/DSA/Time_and_space.md
@@ -2,7 +2,7 @@
 title: "Time and Space Complexity in DSA - Complete Guide"
 description: "A comprehensive guide to understanding time and space complexity in Data Structures and Algorithms (DSA). Learn Big-O notation, performance optimization, real-world examples, and analysis tools."
 ## Keywords 
-Keywords: 
+keywords: 
 - Time Complexity  
 - Space Complexity  
 - Big-O Notation  
@@ -31,7 +31,7 @@ Keywords:
 - Algorithmic Paradigms  
 
 ## Tags  
-Tags:  
+tags:  
 - Time Complexity  
 - Space Complexity  
 - Big-O Notation  

--- a/docs/MLIR/intro.md
+++ b/docs/MLIR/intro.md
@@ -1,6 +1,8 @@
 ---
 title: "Introduction to MLIR"
 description: "Learn about MLIR, its architecture, features, and how it can be utilized in building advanced compiler infrastructures."
+
+
 keywords: 
   - MLIR
   - multi-level intermediate representation
@@ -9,6 +11,20 @@ keywords:
   - machine learning
   - optimization
   - extensibility
+
+tags:
+  - MLIR
+  - Compiler Design
+  - Intermediate Representation
+  - Machine Learning
+  - Compiler Infrastructure
+  - Programming Languages
+  - Optimization
+  - LLVM
+  - Code Generation
+  - MLIR Basics
+
+
 author: "CompilerSutra"
 date: "2024-10-28"
 ---

--- a/docs/c++/advance/index.md
+++ b/docs/c++/advance/index.md
@@ -1,3 +1,45 @@
+---
+title: Advanced C++
+
+description: A deep dive into advanced C++ concepts including templates, memory management, STL, metaprogramming, move semantics, and modern best practices introduced in C++11 and beyond.
+
+id: advanced-cpp
+
+tags:
+- C++  
+- Advanced C++  
+- C++11  
+- C++14  
+- C++17  
+- Templates  
+- STL  
+- Memory Management  
+- Modern C++  
+- Move Semantics  
+- Multithreading  
+- Smart Pointers  
+- Lambda Functions  
+- Compile-Time Programming  
+- Object-Oriented Programming
+
+keywords:
+- Advanced C++ Tutorials  
+- Template Programming in C++  
+- C++ Memory Management  
+- C++ STL Advanced  
+- Move Semantics Explained  
+- Smart Pointers in C++  
+- Multithreading in C++  
+- Lambda Expressions  
+- C++11 Features  
+- Compile-Time Metaprogramming  
+- Best Practices in Modern C++  
+- Type Inference  
+- RAII in C++  
+- Function Objects and Functors  
+- Advanced Object-Oriented Concepts
+
+---
 # 🌟 Advanced C++ Topics
 
 Welcome to the advanced realm of C++ programming! This section is designed for experienced programmers ready to take their skills to the next level.

--- a/docs/c++/advance/intro.md
+++ b/docs/c++/advance/intro.md
@@ -1,0 +1,37 @@
+---
+title: Introduction to Advanced C++
+
+description: An introductory guide to the advanced features of C++ programming, covering templates, smart pointers, the Standard Template Library (STL), and foundational concepts in modern C++.
+
+id: intro
+
+tags:
+- C++  
+- Advanced C++  
+- C++ Basics  
+- C++11  
+- STL  
+- Smart Pointers  
+- Templates  
+- Modern C++  
+- Programming Concepts  
+- Object-Oriented Programming
+
+keywords:
+- Introduction to Advanced C++  
+- C++ Templates  
+- Smart Pointers in C++  
+- STL Overview  
+- Modern C++ Concepts  
+- Object-Oriented Programming in C++  
+- C++11 Features  
+- RAII in C++  
+- Intro to Move Semantics  
+- Type Inference in C++  
+- C++ Best Practices  
+- Function Templates  
+- Class Templates  
+- Introduction to C++ STL  
+- Efficient C++ Programming
+
+---

--- a/docs/c++/basic/cpp_tutorial_with_cmake.md
+++ b/docs/c++/basic/cpp_tutorial_with_cmake.md
@@ -1,22 +1,40 @@
 ---
-id: cpp_tutorial_with_cmake
-title: Comprehensive C++ Tutorial with Basic CMake
-description: Learn the basics of C++ and set up a CMake project from scratch. Understand the importance of C++ in modern development, including object-oriented programming, modern C++ features, and how CMake simplifies building and managing projects.
-keywords: 
-  - C++ tutorial
-  - C++ basics
-  - C++ build systems
-  - CMake tutorial
-  - Object-Oriented Programming
-  - Modern C++
-  - STL
-  - Industry best practices
-author: CompilerSutra
-date: 2024-10-09
-tags: 
+id: cpp-tutorial-with-cmake
+title: C++ Tutorial with CMake
+description: |
+  This tutorial provides a complete walkthrough of setting up and building C++ projects using CMake. Learn the basics of creating `CMakeLists.txt` files, organizing project structure, linking libraries, and compiling code efficiently. Ideal for beginners and intermediate developers who want to modernize their C++ development workflow using CMake.
+keywords:
   - C++
   - CMake
-  - build systems
+  - CMake Tutorial
+  - Modern C++ Development
+  - C++ Project Structure
+  - C++ Build System
+  - CMakeLists
+  - Linking Libraries
+  - C++ Compilation
+  - Build Automation
+  - Cross-Platform Development
+  - C++ Tools
+  - C++ Workflow
+  - CMake for Beginners
+  - C++ Project Setup
+
+tags:
+  - C++
+  - CMake
+  - Build System
+  - CMakeLists
+  - Linking Libraries
+  - Project Setup
+  - Build Automation
+  - Cross-Platform
+  - Modern C++ Workflow
+  - C++ Compilation
+  - Cpp CMake
+
+author: CompilerSutra
+date: 2024-10-09
 slug: /cpp_tutorial_with_cmake
 sidebar_label: cpp_tutorial_with_cmake 
 ---

--- a/docs/c++/basic/index.md
+++ b/docs/c++/basic/index.md
@@ -1,3 +1,49 @@
+---
+id: BasicCppTopics
+title: Basic C++ Topics - Understanding the Fundamentals of C++ Programming
+description: |
+  This guide covers the fundamental topics every beginner needs to know to get started with C++ programming. From understanding variables, data types, and operators to mastering control flow, loops, and functions, this tutorial will give you a solid foundation in C++ programming. Learn the essential building blocks of C++ and how to write your first C++ program with ease.
+keywords:
+  - Basic C++ Topics
+  - C++ Programming Basics
+  - C++ Syntax
+  - Variables in C++
+  - Data Types in C++
+  - C++ Operators
+  - Control Flow in C++
+  - Loops in C++
+  - C++ Functions
+  - Arrays in C++
+  - C++ Input/Output
+  - C++ Conditionals
+  - C++ Statements
+  - C++ Expressions
+  - C++ Beginners Guide
+  - Introduction to C++
+  - C++ for Beginners
+  - C++ Basics Tutorial
+
+tags:
+  - Basic C++ Topics
+  - C++ Programming Basics
+  - C++ Syntax
+  - Variables in C++
+  - Data Types in C++
+  - Operators in C++
+  - Control Flow in C++
+  - Loops in C++
+  - Functions in C++
+  - Arrays in C++
+  - C++ Input/Output
+  - C++ Conditionals
+  - Statements and Expressions
+  - C++ for Beginners
+  - Introduction to C++
+  - C++ Basics Tutorial
+  - C++ Fundamentals
+  - C++ Programming Essentials
+
+---
 # 🌟 Basic C++ Topics
 
 Welcome to the world of C++ programming! Dive into these foundational topics and unlock the potential of this powerful language.

--- a/docs/c++/basic/intro.md
+++ b/docs/c++/basic/intro.md
@@ -1,16 +1,55 @@
 ---
-id: comprehensive-cpp-tutorial
-title: Comprehensive C++ Tutorial with Practical Applications
-description: A detailed and structured guide to learning C++ with real-world applications, object-oriented programming, modern features, and industry standards.
+id: Comprehensive-Cpp-Tutorial
+title: Comprehensive C++ Tutorial - Master C++ from Basics to Advanced Concepts
+description: |
+  This comprehensive C++ tutorial is designed to take you through every aspect of C++ programming, from beginner to advanced topics. Learn the basics of C++ syntax, control structures, data types, and functions, then dive deeper into advanced topics like object-oriented programming (OOP), memory management, templates, the Standard Template Library (STL), and multi-threading. Whether you're just starting out or looking to refine your skills, this tutorial is your one-stop resource for mastering C++.
 keywords:
-  - C++
-  - C++ tutorial
-  - Object-Oriented Programming
-  - Modern C++
-  - Build Systems
-  - Introduction to C++
-  - STL
-  - Industry Best Practices
+  - Comprehensive C++ Tutorial
+  - Master C++ Programming
+  - C++ Basics
+  - C++ Advanced Concepts
+  - Object-Oriented Programming in C++
+  - C++ Functions
+  - C++ Data Structures
+  - C++ Templates
+  - C++ STL
+  - C++ Memory Management
+  - C++ Classes and Objects
+  - C++ Smart Pointers
+  - C++ Lambda Expressions
+  - C++ Multi-threading
+  - C++ Exception Handling
+  - C++ Inheritance
+  - C++ Polymorphism
+  - C++ Algorithms
+  - C++ Best Practices
+  - C++ Interview Preparation
+
+tags:
+  - Comprehensive C++ Tutorial
+  - Master C++ Programming
+  - C++ Basics
+  - C++ Advanced Concepts
+  - Object-Oriented Programming (OOP)
+  - C++ Functions
+  - Data Structures in C++
+  - C++ Templates
+  - C++ STL
+  - Memory Management in C++
+  - C++ Classes and Objects
+  - Smart Pointers in C++
+  - Lambda Expressions in C++
+  - C++ Multi-threading
+  - C++ Exception Handling
+  - C++ Inheritance
+  - C++ Polymorphism
+  - C++ Algorithms
+  - C++ Best Practices
+  - C++ Coding Standards
+  - C++ Interview Preparation
+  - C++ for Beginners and Experts
+  - C++ Performance Optimization
+
 slug: /cpp-tutorial
 sidebar_label: Comprehensive C++ Tutorial
 ---

--- a/docs/c++/basic/opp-cpp.md
+++ b/docs/c++/basic/opp-cpp.md
@@ -1,15 +1,49 @@
 ---
-id: oop-in-cpp
-title: 🧠 OOP in C++ We’re All Just Fancy Objects, Aren’t We?
-description: A sarcastic and fun introduction to OOP concepts in C++ using Homo sapiens sapiens as a class and object example. Enjoy the sass and the C++ magic!
-sidebar_label: OOP with Humor 😎
-slug: /opp-in-cpp
+id: OOPinCpp
+title: OOP in C++ - We’re All Just Fancy Objects, Aren’t We?
+description: |
+  Explore the core principles of Object-Oriented Programming (OOP) in C++ and how they enable the creation of efficient and modular code. Learn about key concepts such as classes, objects, inheritance, polymorphism, encapsulation, and abstraction. This tutorial will help you understand how to design and implement OOP features in C++ to write clean, maintainable, and reusable code.
 keywords:
+  - OOP in C++
   - Object-Oriented Programming
-  - C++ OOP
-  - Classes and Objects in C++
-  - C++ Programming
-  - OOP Concepts
+  - C++ Classes and Objects
+  - Inheritance in C++
+  - C++ Polymorphism
+  - C++ Abstraction
+  - C++ Encapsulation
+  - C++ Constructors and Destructors
+  - C++ Access Modifiers
+  - C++ Function Overloading
+  - C++ Operator Overloading
+  - C++ Virtual Functions
+  - C++ Interfaces
+  - C++ Design Principles
+  - C++ Code Reusability
+  - C++ Object Design
+  - Object-Oriented Design Patterns
+  - C++ Object Modeling
+
+tags:
+  - OOP in C++
+  - Object-Oriented Programming
+  - C++ Classes and Objects
+  - Inheritance
+  - Polymorphism in C++
+  - C++ Abstraction
+  - Encapsulation in C++
+  - Constructors and Destructors
+  - Access Modifiers in C++
+  - Function Overloading
+  - Operator Overloading
+  - Virtual Functions in C++
+  - C++ Interfaces
+  - C++ Design Patterns
+  - Code Reusability in C++
+  - Object-Oriented Design
+  - C++ Object Modeling
+  - C++ Best Practices
+  - Object-Oriented Design Principles
+
 
 ---
 

--- a/docs/c++/c++_main_file.md
+++ b/docs/c++/c++_main_file.md
@@ -1,3 +1,60 @@
+---
+id: CppTutorial
+title: C++ Tutorial - Master the Fundamentals and Advanced Concepts
+description: |
+  Dive into this comprehensive C++ tutorial, designed for beginners and experienced programmers alike. From basic syntax to advanced concepts like OOP, memory management, pointers, and multi-threading, this tutorial will help you master C++. Whether you're just starting out or looking to sharpen your skills, this guide covers everything you need to know to become proficient in C++ programming.
+keywords:
+  - C++ Tutorial
+  - C++ Programming
+  - C++ Basics
+  - C++ Syntax
+  - Object-Oriented Programming
+  - C++ Pointers
+  - C++ Functions
+  - Memory Management in C++
+  - C++ Data Structures
+  - C++ Arrays
+  - C++ Loops
+  - C++ Classes and Objects
+  - C++ Inheritance
+  - C++ Polymorphism
+  - C++ Encapsulation
+  - C++ Abstraction
+  - C++ Templates
+  - C++ Multi-threading
+  - C++ Standard Library
+  - C++ Exception Handling
+  - C++ Best Practices
+
+tags:
+  - C++ Tutorial
+  - C++ Programming
+  - C++ Basics
+  - C++ Syntax
+  - Object-Oriented Programming (OOP)
+  - C++ Functions
+  - C++ Pointers
+  - Memory Management
+  - C++ Data Structures
+  - Arrays in C++
+  - C++ Loops
+  - C++ Classes
+  - C++ Objects
+  - C++ Inheritance
+  - Polymorphism in C++
+  - C++ Abstraction
+  - C++ Encapsulation
+  - Templates in C++
+  - C++ Multi-threading
+  - C++ Exception Handling
+  - C++ Standard Library
+  - C++ Best Practices
+  - C++ Algorithms
+  - C++ for Beginners
+  - Advanced C++ Concepts
+  - C++ Interview Preparation
+
+---
 # 🎓 C++ Tutorial
 
 Welcome to the **C++ Tutorial** section! Choose from the categories below to dive into specific topics and elevate your C++ programming skills:

--- a/docs/c++/intermediate/index.md
+++ b/docs/c++/intermediate/index.md
@@ -1,3 +1,55 @@
+---
+id: IntermediateCpp
+title: Intermediate C++ - Dive Deeper into Advanced C++ Concepts
+description: |
+  Take your C++ skills to the next level with this intermediate-level tutorial. Explore topics such as object-oriented programming (OOP), advanced memory management, pointers, templates, and the Standard Template Library (STL). This guide is ideal for programmers who are familiar with the basics of C++ and are looking to master more complex aspects of the language to write efficient, optimized code.
+keywords:
+  - Intermediate C++
+  - C++ Advanced Concepts
+  - Object-Oriented Programming
+  - Memory Management in C++
+  - C++ Templates
+  - C++ Standard Template Library (STL)
+  - C++ Smart Pointers
+  - C++ Lambda Expressions
+  - C++ Inheritance
+  - C++ Polymorphism
+  - C++ Exception Handling
+  - C++ Multithreading
+  - C++ File I/O
+  - C++ Data Structures
+  - C++ Algorithms
+  - C++ Design Patterns
+  - C++ Function Pointers
+  - C++ Type Casting
+  - C++ Template Specialization
+  - C++ Move Semantics
+
+tags:
+  - Intermediate C++
+  - Advanced C++ Concepts
+  - Object-Oriented Programming (OOP)
+  - Memory Management
+  - C++ Templates
+  - C++ STL
+  - C++ Smart Pointers
+  - C++ Lambda Expressions
+  - C++ Inheritance
+  - C++ Polymorphism
+  - C++ Exception Handling
+  - Multithreading in C++
+  - C++ File I/O
+  - C++ Algorithms
+  - C++ Design Patterns
+  - Function Pointers in C++
+  - C++ Type Casting
+  - C++ Move Semantics
+  - C++ Data Structures
+  - C++ for Intermediate Programmers
+  - C++ Performance Optimization
+  - C++ Memory Management Techniques
+
+---
 # 🌟 Intermediate C++ Topics
 
 Welcome back to your C++ programming journey! This section is filled with more complex concepts that will deepen your understanding and sharpen your coding skills.

--- a/docs/c++/intermediate/intro.md
+++ b/docs/c++/intermediate/intro.md
@@ -1,16 +1,51 @@
 ---
-title: Intro to C++11 vs C++14
-description: Explore the key differences, improvements, and optimizations between C++11 and C++14, including features like relaxed constexpr, variable templates, and generic lambdas.
+id: IntroToCpp11VsCpp14
+title: Introduction to C++11 vs C++14 - Key Differences and Enhancements
+description: |
+  Discover the key differences between C++11 and C++14 in this comprehensive guide. Learn about the new features and improvements introduced in C++14 that build upon the foundation set by C++11. This tutorial compares both versions and highlights the changes in syntax, performance, and functionality to help you understand which version is best suited for your development needs.
 keywords:
   - C++11
   - C++14
-  - C++ differences
-  - constexpr
-  - variable templates
-  - generic lambdas
-  - compile-time computation
-  - C++ standard library
-  - C++ performance optimization
+  - C++ Language Features
+  - C++ Comparison
+  - C++ Syntax
+  - C++11 Features
+  - C++14 Features
+  - C++ Performance
+  - C++ Lambda Expressions
+  - C++ Auto Keyword
+  - C++ Type Inference
+  - C++ Smart Pointers
+  - C++ Move Semantics
+  - C++ Multithreading
+  - C++ Compile-Time Features
+  - C++ Static Assertions
+  - C++14 Improvements
+  - C++11 vs C++14
+  - C++ Coding Standards
+
+tags:
+  - C++11
+  - C++14
+  - C++ Language Features
+  - C++ Comparison
+  - C++ Syntax
+  - C++ Features
+  - C++ Performance
+  - C++ Lambda Expressions
+  - C++ Auto Keyword
+  - C++ Type Inference
+  - C++ Smart Pointers
+  - C++ Move Semantics
+  - C++ Multithreading
+  - C++ Compile-Time Features
+  - C++ Static Assertions
+  - C++14 Enhancements
+  - C++11 Features
+  - C++ Coding Standards
+  - C++ Standards Comparison
+  - C++ Language Evolution
+
 ---
 
 # Introduction

--- a/docs/c++/standard/C++11.md
+++ b/docs/c++/standard/C++11.md
@@ -11,6 +11,21 @@ keywords:
   - STL
   - Industry Best Practices
   - C++11
+tags:
+- C++
+- C++11
+- Programming Languages
+- Modern C++
+- C++ Standards
+- Software Development
+- Lambda Functions
+- Memory Management
+- Object-Oriented Programming
+- Type Inference
+- Move Semantics
+- C++ Features
+- C++ Improvements
+
 slug: /C++11
 sidebar_label: C++11
 ---

--- a/docs/c++/standard/cpp11.md
+++ b/docs/c++/standard/cpp11.md
@@ -2,15 +2,40 @@
 id: intro
 title: C++11 Docs
 description: A detailed and structured guide to learning C++11 with documentation study, object-oriented programming, modern features, and industry standards which we need to learn about the C++11 standard.
-keywords:
-  - C++
-  - C++ tutorial
-  - Object-Oriented Programming
-  - Modern C++
-  - Build Systems
-  - STL
-  - Industry Best Practices
-  - C++11
+tags:  
+- C++  
+- C++11  
+- Modern C++  
+- Programming Language  
+- Software Development  
+- C++ Standards  
+- Lambda Functions  
+- Smart Pointers  
+- Move Semantics  
+- Auto Keyword  
+- Type Inference  
+- Concurrency  
+- Multithreading  
+- Range-based Loops  
+- Rvalue References  
+
+keywords:  
+- C++11 Features  
+- New Additions in C++11  
+- Lambda in C++  
+- C++ Smart Pointers  
+- Memory Management in C++  
+- Move Semantics  
+- Auto and Decltype  
+- C++ Concurrency  
+- Multithreading in C++  
+- C++ Performance  
+- Type Inference in C++  
+- Range Loops  
+- Rvalue vs Lvalue  
+- C++ Programming  
+- Modern Programming Techniques  
+
 slug: /C++11
 sidebar_label: C++11
 ---

--- a/docs/c++/standard/index.md
+++ b/docs/c++/standard/index.md
@@ -1,3 +1,43 @@
+---
+id: intro
+
+title: Standars in C++
+
+description: Overview of the C++11 standard, introducing modern features such as auto type deduction, lambda expressions, range-based for loops, smart pointers, and enhancements to performance and code clarity in C++ programming.
+
+keywords:
+- C++11
+- Modern C++
+- C++ Standards
+- Lambda Expressions
+- Smart Pointers
+- auto Keyword
+- Range-based for Loop
+- Rvalue References
+- Move Semantics
+- nullptr
+- Type Inference
+- Uniform Initialization
+- C++ Performance
+- C++ Features
+- C++ Evolution
+
+tags: 
+- C++
+- C++11
+- Programming Languages
+- Modern C++
+- C++ Features
+- Object-Oriented Programming
+- Language Standards
+- Software Development
+- C++ Syntax
+- Code Optimization
+- Static Typing
+- Memory Management
+- Compiler Features
+- Type Inference
+---
 # 🌟 Standard C++ Topics
 
 Welcome to the essential section of C++ programming! Here, you’ll learn about the C++ Standard Library and the conventions that will help you write more efficient and effective code.

--- a/docs/c++/standard/intro.md
+++ b/docs/c++/standard/intro.md
@@ -1,0 +1,41 @@
+---
+title: Introduction to Standard C++
+
+description: An introductory guide to the evolution, core concepts, and features of the Standard C++ programming language, including its various versions and standardization process.
+
+id: introduction-to-standard-cpp
+
+tags:
+- C++  
+- Standard C++  
+- C++ Standards  
+- Programming Language  
+- Software Development  
+- C++ Versions  
+- C++ History  
+- Modern C++  
+- C++11  
+- C++14  
+- C++17  
+- C++20  
+- C++23  
+- Compilation  
+- C++ Evolution
+
+keywords:
+- C++ Programming Language  
+- Standardization of C++  
+- ISO C++  
+- C++ Versions Explained  
+- C++11 to C++23  
+- Introduction to C++  
+- Modern C++ Features  
+- Evolution of C++ Standards  
+- Compilation and Standards  
+- C++ Overview  
+- C++ Features Timeline  
+- Understanding C++ Updates  
+- Core Concepts in C++  
+- Standard Template Library  
+- Language Standards
+---

--- a/docs/compilers/CPU/index.md
+++ b/docs/compilers/CPU/index.md
@@ -1,3 +1,45 @@
+---
+title: CPU Compilers
+
+description: An insightful overview of CPU-targeted compilers, focusing on architecture-aware optimizations, instruction scheduling, register usage, and backend techniques tailored for modern processor designs.
+
+id: cpu-compilers
+
+tags:
+- Compilers  
+- CPU Architecture  
+- Code Generation  
+- Instruction Scheduling  
+- Register Allocation  
+- Optimization  
+- LLVM  
+- Backend Compiler  
+- Systems Programming  
+- Low-Level Programming  
+- Performance Engineering  
+- Compiler Design  
+- Target-Specific Compilation  
+- Microarchitecture  
+- Instruction Sets
+
+keywords:
+- CPU Compiler Fundamentals  
+- Compiler Design for Processors  
+- Instruction-Level Optimization  
+- Register Allocation Strategies  
+- Code Optimization for CPUs  
+- Instruction Pipelining  
+- x86 Compilation Techniques  
+- ARM Code Generation  
+- Low-Level Optimizations  
+- Microarchitectural Considerations in Compilation  
+- Target-Specific Compiler Passes  
+- CPU Backend Implementation  
+- Compiler Scheduling Algorithms  
+- Performance-Tuned Compilation  
+- Platform-Specific Code Generation
+
+---
 # 💻 CPU Compilers
 
 CPU compilers are designed to optimize for instruction-level parallelism and cache efficiency. Learn about CPU-specific optimizations and architecture-specific instructions.

--- a/docs/compilers/GPU/index.md
+++ b/docs/compilers/GPU/index.md
@@ -1,3 +1,45 @@
+---
+title: GPU Compilers
+
+description: An in-depth overview of GPU compilers, their role in translating high-level code to GPU-executable instructions, and how they optimize for parallelism, memory, and performance.
+
+id: gpu-compilers
+
+tags:
+- GPU Compilers
+- CUDA
+- OpenCL
+- Parallel Computing
+- GPU
+- LLVM
+- HLSL
+- SPIR-V
+- GPU Code Optimization
+- Compiler Design
+- Code Generation
+- GPU Architecture
+- NVIDIA
+- AMD
+- AI Accelerators
+
+keywords:
+- What is a GPU compiler  
+- CUDA compiler toolchain  
+- OpenCL kernel compilation  
+- GPU code optimization techniques  
+- LLVM-based GPU compilers  
+- PTX and SASS code generation  
+- GPU intermediate representations  
+- SPIR-V and Vulkan shaders  
+- Parallelism in GPU compilers  
+- GPU register usage  
+- Shared memory optimization  
+- Compiler support for tensor cores  
+- Deep learning compiler stacks  
+- MLIR and GPU dialects  
+- Cross-platform GPU code generation
+
+---
 # ⚙️ GPU Compilers
 
 Compiling for GPUs involves optimizing for parallelism and efficient memory use. Explore GPU compilers, including their specific back-end optimizations and threading models.

--- a/docs/compilers/Know_Your_Compilers.md
+++ b/docs/compilers/Know_Your_Compilers.md
@@ -1,3 +1,30 @@
+---
+title: "Know Your Compiler"
+description:  "Discover the inner workings of compilers in this insightful guide. From basic concepts to advanced features, learn how compilers transform source code into executable programs, optimize code, and handle different programming languages. Ideal for both beginners and experienced programmers looking to deepen their understanding of compiler technology."
+
+keywords:
+  - Compiler
+  - Source Code
+  - Compiler Design
+  - Optimization
+  - Programming Languages
+  - Compiler Architecture
+  - Code Generation
+  - Code Optimization
+  - Compiler Features
+  - Compiler Theory
+  - Compiler Tools
+
+tags:
+  - Compiler Design
+  - Programming
+  - Software Development
+  - Code Optimization
+  - Compiler Technology
+  - Programming Languages
+
+
+---
 
 ### Compiler Stages with Clang
 Newbies who have just started their journey in compiler development often have a basic understanding of how a compiler works. They know it isn't just a mysterious black box. But have you ever wondered how each stage in the compiler pipeline looks and works?

--- a/docs/compilers/back_end/index.md
+++ b/docs/compilers/back_end/index.md
@@ -1,3 +1,45 @@
+---
+title: Introduction to Backend Compilers
+
+description: A comprehensive introduction to backend compiler design, exploring code generation, optimization, intermediate representations, register allocation, and platform-specific backend architecture.
+
+id: introduction-to-backend-compilers
+
+tags:
+- Compilers  
+- Backend Compiler  
+- Code Generation  
+- Intermediate Representation  
+- LLVM  
+- Register Allocation  
+- Optimization  
+- Programming Languages  
+- Assembly  
+- Computer Architecture  
+- Systems Programming  
+- Compiler Design  
+- Backend Engineering  
+- IR Optimization  
+- Low-Level Programming
+
+keywords:
+- Backend Compiler Overview  
+- Code Generation Techniques  
+- Compiler Intermediate Representations  
+- LLVM Backend  
+- Register Allocation Algorithms  
+- Instruction Selection  
+- Platform-Specific Compiler Design  
+- Target Architecture in Compilers  
+- Backend Optimization Passes  
+- Assembly Code Generation  
+- IR to Machine Code Translation  
+- Low-Level Compiler Concepts  
+- Instruction Scheduling  
+- C++ in Compiler Development  
+- Systems-Level Programming Tools
+
+---
 # 🏗️ Compiler Back End
 
 The back end is where optimization and code generation happen. Learn how the compiler transforms intermediate code into optimized machine code.

--- a/docs/compilers/compiler.md
+++ b/docs/compilers/compiler.md
@@ -1,3 +1,29 @@
+---
+id: Compiler
+title: Know Your Compiler - A Comprehensive Guide to Understanding Compilers and Their Features
+description: |
+  Discover the inner workings of compilers in this insightful guide. From basic concepts to advanced features, learn how compilers transform source code into executable programs, optimize code, and handle different programming languages. Ideal for both beginners and experienced programmers looking to deepen their understanding of compiler technology.
+keywords:
+  - Compiler
+  - Source Code
+  - Compiler Design
+  - Optimization
+  - Programming Languages
+  - Compiler Architecture
+  - Code Generation
+  - Code Optimization
+  - Compiler Features
+  - Compiler Theory
+  - Compiler Tools
+tags:
+  - Compiler Design
+  - Programming
+  - Software Development
+  - Code Optimization
+  - Compiler Technology
+  - Programming Languages
+
+---
 # 🔍 Know Your Compilers
 
 Welcome to the **Compiler Documentation**! Explore each stage and component of the compiler, from front-end parsing to architecture-specific optimizations for GPU, CPU, and more.

--- a/docs/compilers/flag/index.md
+++ b/docs/compilers/flag/index.md
@@ -1,3 +1,45 @@
+---
+title: Compiler Flags
+
+description: A comprehensive guide to understanding and using compiler flags across major compilers like GCC, Clang, and MSVC for controlling optimization levels, debugging, warnings, linking, and more.
+
+id: compiler-flags
+
+tags:
+- Compiler Flags
+- GCC
+- Clang
+- MSVC
+- Optimization
+- Debugging
+- Linking
+- Build Configuration
+- Command Line Tools
+- Compilation Options
+- Systems Programming
+- Code Quality
+- Warnings
+- Cross-Compilation
+- Performance Tuning
+
+keywords:
+- GCC Compiler Flags  
+- Clang Compilation Options  
+- MSVC Build Settings  
+- -O2 vs -O3 Optimization  
+- -Wall and Warning Flags  
+- Debug Symbols with -g  
+- Linker Flags (-l, -L)  
+- Preprocessor Flags (-D, -U)  
+- Target Architecture Flags (-m64, -march)  
+- Build System Integration  
+- Compilation Control  
+- Performance Optimization Flags  
+- Sanitizer Flags (ASan, UBSan)  
+- Custom Build Configurations  
+- Flag Combinations for Debug vs Release
+
+---
 # 🚩 Compiler Flags
 
 Compiler flags control various aspects of how code is compiled. This section covers optimization, debugging, and architecture-specific flags, giving you fine-grained control over the compilation process.

--- a/docs/compilers/front_end/index.md
+++ b/docs/compilers/front_end/index.md
@@ -1,3 +1,45 @@
+---
+title: Compiler Frontend
+
+description: Introduction to the Compiler Frontend – the stage of compilation responsible for lexical analysis, parsing, syntax checking, semantic analysis, and intermediate representation (IR) generation.
+
+id: compiler-frontend
+
+tags:
+- Compiler Frontend
+- Compilation Stages
+- Lexical Analysis
+- Parsing
+- Syntax Trees
+- Semantic Analysis
+- Intermediate Representation
+- Programming Languages
+- Compiler Design
+- Source Code Analysis
+- Syntax Checking
+- Tokenization
+- AST
+- IR Generation
+- Frontend Technologies
+
+keywords:
+- What is a compiler frontend  
+- Lexical analysis process  
+- Token generation in compilers  
+- Abstract Syntax Tree (AST)  
+- Parser design (LL, LR)  
+- Semantic checks in compilers  
+- Frontend role in compilation  
+- Intermediate representation generation  
+- Compiler frontend vs backend  
+- Frontend optimizations  
+- Source code analysis tools  
+- Frontend diagnostics and error handling  
+- Frontend technologies in modern compilers  
+- Compiler phases overview  
+- Programming language frontends
+
+---
 # 🛠️ Compiler Front End
 
 The front end of a compiler is responsible for analyzing source code syntax and generating an intermediate representation. This section explores lexical analysis, parsing, and Abstract Syntax Tree (AST) generation.

--- a/docs/compilers/intro.md
+++ b/docs/compilers/intro.md
@@ -1,4 +1,30 @@
+---
+id: IntroductionToCompilers
+title: Introduction to Compilers - Understanding the Basics and Functionality
+description: |
+  Get an overview of compiler fundamentals in this beginner-friendly guide. Learn the essential stages of compilation, the role of a compiler in software development, and how it transforms human-readable code into machine-readable instructions. This guide is perfect for newcomers to programming and compiler design.
+keywords:
+  - Compiler
+  - Compilation Process
+  - Compiler Basics
+  - Programming Languages
+  - Code Transformation
+  - Code Generation
+  - Syntax Analysis
+  - Compiler Phases
+  - Compiler Theory
+  - Software Development
+  - Machine Code
+tags:
+  - Compiler Basics
+  - Programming
+  - Software Development
+  - Compiler Theory
+  - Code Transformation
+  - Programming Languages
 
+
+---
 # Introduction to Compilers
 
 ## What is a Compiler?

--- a/docs/compilers/nvidia_vs_amd_opencl.md
+++ b/docs/compilers/nvidia_vs_amd_opencl.md
@@ -1,3 +1,30 @@
+---
+id: NvidiaVsAmdOpenCL
+title: NVIDIA vs AMD OpenCL - A Comparison of GPU Performance and OpenCL Support
+description: |
+  Explore the differences between NVIDIA and AMD GPUs when it comes to OpenCL support and performance. This guide compares how each company’s hardware handles OpenCL, highlighting key features, performance metrics, and the overall ecosystem for developers. Learn which GPU offers better performance for your OpenCL-based applications and how to choose the best option for your needs.
+keywords:
+  - NVIDIA
+  - AMD
+  - OpenCL
+  - GPU Performance
+  - Hardware Comparison
+  - Graphics Processing Units
+  - GPU Architecture
+  - OpenCL Support
+  - Parallel Computing
+  - AMD vs NVIDIA
+  - OpenCL Optimization
+tags:
+  - NVIDIA
+  - AMD
+  - OpenCL
+  - GPU Performance
+  - Parallel Computing
+  - Hardware Comparison
+  - Graphics Processing Units
+
+---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docs/compilers/other_arch/index.md
+++ b/docs/compilers/other_arch/index.md
@@ -1,3 +1,45 @@
+---
+title: Other Architectures
+
+description: A comprehensive guide to non-mainstream or emerging hardware architectures, including RISC-V, ARM, FPGA, and ASICs, focusing on their compiler support, use cases, and optimization techniques.
+
+id: other-architectures
+
+tags:
+- RISC-V
+- ARM Architecture
+- FPGA
+- ASIC
+- Embedded Systems
+- SoC
+- Compiler Support
+- Hardware Acceleration
+- Edge Computing
+- Instruction Sets
+- ISA
+- Low Power Computing
+- Hardware Optimization
+- Custom Architectures
+- Architecture Design
+
+keywords:
+- Alternative processor architectures  
+- RISC-V compiler ecosystem  
+- ARM vs x86 architecture  
+- FPGA code compilation  
+- ASIC design and toolchains  
+- Compiler backends for embedded chips  
+- Instruction set customization  
+- VLIW and DSP architectures  
+- Edge AI hardware compilation  
+- Cross-compilation for custom hardware  
+- LLVM support for RISC-V and ARM  
+- FPGA synthesis and HLS  
+- Domain-specific architecture compilers  
+- Power-efficient chip architectures  
+- Modern ISA trends
+
+---
 # 🌍 Other Architectures
 
 From embedded systems to FPGAs, compilers for various architectures require unique optimizations and considerations.

--- a/docs/gpu/optimizations.md
+++ b/docs/gpu/optimizations.md
@@ -1,0 +1,36 @@
+---
+id: OptimizationOfGPU
+title: Optimization of GPU - Techniques for Enhancing GPU Performance
+description: |
+  Learn about various techniques and strategies to optimize GPU performance for faster and more efficient computing. This guide covers memory management, parallel processing, kernel optimization, and the best practices for utilizing GPU resources effectively. Ideal for developers looking to get the most out of their GPU in high-performance computing tasks, machine learning, and gaming.
+keywords:
+  - GPU Optimization
+  - Parallel Computing
+  - GPU Performance
+  - Memory Management
+  - Kernel Optimization
+  - Graphics Processing Unit
+  - High-Performance Computing
+  - Machine Learning
+  - GPU Programming
+  - Performance Tuning
+  - Resource Management
+tags:
+  - GPU Optimization
+  - Parallel Computing
+  - Machine Learning
+  - High-Performance Computing
+  - GPU Programming
+  - Performance Tuning
+  - Graphics Processing Unit
+  - CUDA
+  - GPU Acceleration
+  - Deep Learning
+  - Computational Efficiency
+  - Hardware Optimization
+  - Memory Hierarchy
+  - Data Throughput
+  - Compute Shaders
+  - GPU Architecture
+  - Multi-threading
+  - Tensor Cores

--- a/docs/llvm/Intermediate/What_Is_LLVM_Passes.md
+++ b/docs/llvm/Intermediate/What_Is_LLVM_Passes.md
@@ -2,6 +2,8 @@
 title: "Understanding LLVM Passes and Their Types"
 description: "Learn about LLVM passes, their purpose, and the different types used in compiler optimizations. Explore frontend, middle-end, and backend passes in detail."
 keywords: [LLVM, Passes, Compiler Optimization, Frontend Passes, Backend Passes, Middle-End Passes, IR, Code Transformation]
+tags: [LLVM, Compiler Passes, LLVM Passes, Optimization, Compiler Design, Intermediate Representation, Code Transformation, Static Analysis, IR Passes, LLVM Internals]
+
 
 ---
 

--- a/docs/llvm/llvm_extras/More_About_LLVM.md
+++ b/docs/llvm/llvm_extras/More_About_LLVM.md
@@ -9,6 +9,25 @@ keywords:
   - "compiler framework"
   - "SSA"
   - "LLVM architecture"
+
+tags: 
+- LLVM
+- Compiler Design
+- Intermediate Representation
+- Code Optimization
+- Static Analysis
+- Code Generation
+- Low-Level Programming
+- IR Passes
+- Programming Tools
+- Backend Development
+- Systems Programming
+- Toolchain
+- JIT Compilation
+- Code Transformation
+- Open Source
+
+
 ---
 
 # 🔍 Unlocking the Power of LLVM

--- a/docs/mcq/cpp_mcqs.md
+++ b/docs/mcq/cpp_mcqs.md
@@ -70,7 +70,8 @@ Sharpen your C++ programming skills with our comprehensive set of multiple-choic
 - [Control Flow: if-else, switch-case](./questions/basic/control-flow.md)
 - [Loops: for, while, do-while](./questions/basic/loops.md)
 - [Functions](./questions/basic/functions.md)
-- [Arrays and Strings](./questions/basic/arrays-and-strings.md)
+- [Arrays and Strings](./questions/basic/array-and-strings.md)
+- [Pointer and Strings](./questions/basic/pointers-strings.md)
 - [Pointers and References](./questions/basic/pointers-and-references.md)
 - [Input and Output](./questions/basic/io.md)
 

--- a/docs/mcq/interview_question/basic/arrays-strings.md
+++ b/docs/mcq/interview_question/basic/arrays-strings.md
@@ -13,6 +13,25 @@ keywords:
 - "C++ Class Design"
 - "C++ Interview Guide"
 - "Master C++ OOP Concepts"
+tags:
+  - Arrays
+  - Strings
+  - Data Structures
+  - Programming Concepts
+  - Algorithms
+  - Memory Management
+  - String Manipulation
+  - Array Operations
+  - Collections
+  - Multi-dimensional Arrays
+  - Dynamic Arrays
+  - Array Sorting
+  - String Searching
+  - String Concatenation
+  - Data Handling
+  - Coding Fundamentals
+  - Array Traversal
+  - String Parsing
 ---
 
 # **Essential C++ Interview Questions on Classes and Objects**

--- a/docs/mcq/interview_question/basic/control-flow.md
+++ b/docs/mcq/interview_question/basic/control-flow.md
@@ -10,6 +10,24 @@ keywords:
   - Conditional Statements in C++
   - Loops and Control Flow in C++
   - C++ Jump Statements Guide
+tags:
+  - Control Flow
+  - Conditional Statements
+  - Loops
+  - If-Else
+  - Switch Statements
+  - For Loops
+  - While Loops
+  - Do-While Loops
+  - Branching
+  - Program Logic
+  - Flow Control
+  - Decision Making
+  - Algorithm Design
+  - Loop Optimization
+  - Code Structure
+  - Programming Fundamentals
+  - Iteration
 ---
 
 # Essential C++ Interview Questions for Freshers

--- a/docs/mcq/interview_question/basic/data-types-variables.md
+++ b/docs/mcq/interview_question/basic/data-types-variables.md
@@ -8,6 +8,29 @@ keywords:
   - Programming Interview Preparation
   - C++ Concepts Explained
   - Data Types and Variables in C++
+tags:
+  - Data Types
+  - Variables
+  - Primitive Data Types
+  - Integer
+  - Float
+  - Double
+  - Char
+  - Boolean
+  - String
+  - Variable Declaration
+  - Variable Scope
+  - Type Casting
+  - Constants
+  - Data Structures
+  - Type Inference
+  - Dynamic Typing
+  - Static Typing
+  - Memory Allocation
+  - Variable Initialization
+  - Type Safety
+  - Variable Naming
+
 ---
 
 # Essential C++ Interview Questions for Freshers

--- a/docs/mcq/interview_question/basic/functions-recursion.md
+++ b/docs/mcq/interview_question/basic/functions-recursion.md
@@ -2,13 +2,45 @@
 title: "Recursion"
 description: "Explore recursion in C++ with examples, base and recursive cases, and how it can be used to solve problems."
 keywords:
-  - Recursion in C++
-  - C++ MCQ for Placement
-  - C++ Recursive Functions
+  - Recursion
+  - Recursive Functions
+  - Base Case
+  - Recursive Call
+  - Algorithm Design
+  - Divide and Conquer
+  - Backtracking
+  - Stack
+  - Function Call Stack
+  - Depth-First Search (DFS)
+  - Tail Recursion
+  - Memoization
+  - Dynamic Programming
+  - Recursive Tree
+  - Problem Solving
+  - Divide and Conquer Algorithm
   - Recursive Algorithms
-  - Base and Recursive Case
-  - Programming Interview Preparation
-  - C++ Concepts for Interviews
+  - Recursion vs Iteration
+
+tags:
+  - Recursion
+  - Recursive Functions
+  - Base Case
+  - Algorithm Design
+  - Problem Solving
+  - Divide and Conquer
+  - Backtracking
+  - Function Call Stack
+  - Stack
+  - Depth-First Search
+  - Tail Recursion
+  - Memoization
+  - Dynamic Programming
+  - Recursive Algorithms
+  - Recursive Tree
+  - Recursive Problem Solving
+  - Algorithm Optimization
+  - Recursion vs Iteration
+
 ---
 # Question on the Recursion in C++
 

--- a/docs/mcq/interview_question/basic/intro-to-cpp.md
+++ b/docs/mcq/interview_question/basic/intro-to-cpp.md
@@ -3,11 +3,47 @@ title: "C++ Interview Questions for Freshers with Answers"
 description: "Comprehensive guide to basic C++ interview questions for freshers. Test your knowledge with detailed questions and answers tailored for programming beginners."
 keywords:
   - C++ Interview Questions
-  - C++ MCQ for Placement
-  - Basic C++ MCQs
-  - Programming for Freshers
+  - Freshers Interview
   - C++ Basics
-  - Interview Preparation
+  - C++ Programming
+  - C++ Interview Preparation
+  - C++ Syntax
+  - Object-Oriented Programming (OOP)
+  - Pointers in C++
+  - C++ Functions
+  - C++ Arrays
+  - C++ Loops
+  - C++ Classes and Objects
+  - C++ Memory Management
+  - C++ Standard Library
+  - C++ Data Structures
+  - C++ Algorithms
+  - C++ Interview Tips
+  - C++ Coding Challenges
+  - C++ for Beginners
+
+tags:
+  - C++ Interview Questions
+  - Interview for Freshers
+  - C++ Basics
+  - C++ Programming
+  - C++ Syntax
+  - Object-Oriented Programming
+  - Pointers in C++
+  - C++ Functions
+  - C++ Arrays
+  - C++ Loops
+  - C++ Classes and Objects
+  - C++ Memory Management
+  - C++ Standard Library
+  - C++ Data Structures
+  - C++ Algorithms
+  - C++ Interview Preparation
+  - C++ Coding Challenges
+  - C++ for Beginners
+  - Programming Interviews
+  - C++ Interview Tips
+
 ---
 
 # C++ Interview Questions 

--- a/docs/mcq/interview_question/basic/io-operations.md
+++ b/docs/mcq/interview_question/basic/io-operations.md
@@ -1,14 +1,47 @@
 ---
 title: "C++ Interview Questions on I/O Operations"
 description: "Top C++ interview questions on input and output operations, including file handling, cin vs getline, and error handling in C++."
-keywords: 
-- "C++ Interview Questions"
-- C++ MCQ for Placement
-- "C++ I/O Operations"
-- "File Handling in C++"
--  "cin vs getline" 
-- "cerr vs clog" 
-- "C++ Streams"
+keywords:
+  - C++ I/O Operations
+  - C++ Input and Output
+  - Stream Classes in C++
+  - File Handling in C++
+  - C++ cin and cout
+  - C++ Input/Output Functions
+  - C++ File Streams
+  - File Handling in C++ Interview
+  - C++ Stream Manipulators
+  - C++ File Reading and Writing
+  - C++ fstream
+  - C++ Data Input
+  - C++ Data Output
+  - C++ Error Handling in I/O
+  - C++ Buffered I/O
+  - C++ Stream Objects
+  - C++ I/O Performance
+  - C++ I/O Interview Questions
+
+tags:
+  - C++ I/O Operations
+  - Input and Output
+  - Stream Classes in C++
+  - File Handling
+  - cin and cout
+  - fstream
+  - File Streams
+  - Stream Manipulators
+  - C++ File Reading
+  - C++ File Writing
+  - I/O Performance
+  - C++ Interview Questions
+  - Error Handling in I/O
+  - C++ Data Input/Output
+  - Buffered I/O
+  - C++ File Operations
+  - I/O Functions in C++
+  - C++ Input/Output Stream
+  - Programming Interviews
+
 ---
 
 # C++ Interview Questions on I/O Operations

--- a/docs/mcq/interview_question/basic/pointers-references.md
+++ b/docs/mcq/interview_question/basic/pointers-references.md
@@ -2,19 +2,46 @@
 title: "Essential C++ Interview Questions on Pointers and References – Master C++ Concepts for Interviews"
 description: "Ace your C++ interviews with our comprehensive guide to the top essential C++ interview questions on pointers and references. Learn key concepts, pointer arithmetic, reference binding, memory management, and common pitfalls. Perfect for beginners and anyone looking to level up their C++ interview preparation."
 keywords:
-  - "C++ Interview Questions"
-  - "C++ MCQ for Placement"
-  - "C++ Pointers and References"
-  - "C++ Memory Management"
-  - "C++ Pointer Arithmetic"
-  - "C++ Smart Pointers"
-  - "C++ References vs Pointers"
-  - "Pointers and References in C++"
-  - "C++ Advanced Interview Questions"
-  - "C++ Beginner Guide"
-  - "Master C++ Interview Concepts"
-  - "C++ Best Practices"
-  - "C++ Pointer Pitfalls"
+  - C++ Pointers
+  - C++ References
+  - C++ Interview Questions
+  - Pointer Concepts in C++
+  - C++ Reference Variables
+  - Pointer Syntax in C++
+  - Memory Management in C++
+  - C++ Dynamic Memory Allocation
+  - Pointer Arithmetic in C++
+  - C++ Function Pointers
+  - C++ Reference vs Pointer
+  - Dereferencing in C++
+  - Null Pointer in C++
+  - C++ Smart Pointers
+  - C++ Pointers to Objects
+  - C++ Const Pointers and References
+  - C++ Interview Preparation
+  - C++ Memory Allocation and Deallocation
+
+tags:
+  - C++ Pointers
+  - C++ References
+  - Pointer Concepts
+  - Reference Variables
+  - C++ Interview Questions
+  - C++ Syntax
+  - C++ Memory Management
+  - Dynamic Memory Allocation
+  - Pointer Arithmetic
+  - Function Pointers in C++
+  - Pointer vs Reference
+  - Dereferencing
+  - Null Pointer
+  - C++ Smart Pointers
+  - Pointers to Objects
+  - Const Pointers and References
+  - C++ Memory Management Interview
+  - C++ Interview Preparation
+  - Memory Allocation and Deallocation
+
 ---
 
 # **Essential C++ Interview Questions on Pointers and References**

--- a/docs/mcq/interview_question/intermediate/classes-object.md
+++ b/docs/mcq/interview_question/intermediate/classes-object.md
@@ -1,18 +1,44 @@
 ---
-title: "Classes and Objects"
-description: "Prepare for C++ interviews with our in-depth guide to essential C++ interview questions on classes and objects. Learn key OOP concepts, encapsulation, constructors, destructors, and object-oriented programming in C++. Ideal for beginners and professionals."
+id: ClassesObjects
+title: Classes and Objects
+description: |
+  This guide focuses on essential C++ interview questions about classes and objects — the fundamental building blocks of object-oriented programming. Learn how classes encapsulate data and behavior, how to create and manipulate objects, and understand key concepts like member functions, access specifiers, constructors, destructors, and more. Prepare for interviews by mastering class design, object instantiation, and object-oriented principles in C++.
 keywords:
-- "C++ Interview Questions"
-- "C++ MCQ for Placement"
-- "C++ Classes and Objects"
-- "C++ OOP Concepts"
-- "Encapsulation in C++"
-- "C++ Constructors and Destructors"
-- "C++ Object-Oriented Programming"
-- "OOP in C++ Interview"
-- "C++ Class Design"
-- "C++ Interview Guide"
-- "Master C++ OOP Concepts"
+  - C++ Interview Questions
+  - Classes and Objects in C++
+  - C++ Class Definition
+  - C++ Object Instantiation
+  - C++ Member Functions
+  - C++ Access Specifiers
+  - C++ Public Private Protected
+  - C++ Object-Oriented Programming
+  - C++ Constructors and Destructors
+  - C++ Class Best Practices
+  - C++ Data Members
+  - C++ Encapsulation
+  - C++ Class Design
+  - C++ Instance Variables
+  - C++ Interview Preparation
+  - C++ Code Reusability
+  - C++ Class Declaration
+
+tags:
+  - C++ Interview Questions
+  - Classes in C++
+  - Objects in C++
+  - Object-Oriented Programming
+  - C++ Member Functions
+  - Access Specifiers in C++
+  - Public Private Protected in C++
+  - Constructors and Destructors
+  - Encapsulation in C++
+  - C++ Class Design
+  - C++ Object Instantiation
+  - C++ Instance Variables
+  - C++ Data Members
+  - C++ Reusability
+  - C++ Interview Preparation
+
 ---
 
 # **Essential C++ Interview Questions on Classes and Objects**

--- a/docs/mcq/interview_question/intermediate/constructors-destructors.md
+++ b/docs/mcq/interview_question/intermediate/constructors-destructors.md
@@ -1,18 +1,44 @@
 ---
-title: "C++ Interview Questions(Constructors and Destructors)"
-description: "Prepare for C++ interviews with this guide to essential C++ interview questions on constructors and destructors. Learn about default, parameterized, copy, move constructors, and best practices."
+id: CppInterviewQuestionsConstructorsDestructors
+title: C++ Interview Questions on Constructors and Destructors
+description: |
+  This guide covers essential C++ interview questions on constructors and destructors, key components in object lifecycle management. Understand the different types of constructors (default, parameterized, copy) and destructors, their roles in memory allocation and deallocation, and how to manage resources effectively. Learn about constructor overloading, initialization lists, and best practices for defining and using destructors in C++ to prevent memory leaks and ensure efficient resource management.
 keywords:
-- "C++ Interview Questions"
-- "C++ MCQ for Placement"
-- "C++ Constructors and Destructors"
-- "C++ Object Lifecycle"
-- "C++ Copy Constructor"
-- "C++ Move Constructor"
-- "C++ Destructor"
-- "C++ Constructor Overloading"
-- "C++ RAII"
-- "C++ Best Practices"
-- "Master C++ Constructors and Destructors"
+  - C++ Interview Questions
+  - Constructors in C++
+  - Destructors in C++
+  - C++ Default Constructor
+  - C++ Parameterized Constructor
+  - C++ Copy Constructor
+  - C++ Constructor Overloading
+  - C++ Destructor
+  - C++ Destructor Best Practices
+  - C++ Resource Management
+  - C++ Constructor Initialization List
+  - C++ Memory Management
+  - C++ Constructor and Destructor Interview
+  - C++ Object Lifecycle
+  - C++ Constructor and Destructor Types
+  - C++ Interview Preparation
+  - C++ Object Creation and Destruction
+
+tags:
+  - C++ Interview Questions
+  - Constructors in C++
+  - Destructors in C++
+  - C++ Default Constructor
+  - C++ Parameterized Constructor
+  - C++ Copy Constructor
+  - Constructor Overloading in C++
+  - Destructor in C++
+  - C++ Destructor Best Practices
+  - C++ Object Lifecycle
+  - C++ Constructor Initialization List
+  - C++ Memory Management
+  - C++ Resource Management
+  - C++ Constructor and Destructor Types
+  - C++ Interview Preparation
+
 ---
 
 # **Essential C++ Interview Questions on Constructors and Destructors**

--- a/docs/mcq/interview_question/intermediate/exception-handling.md
+++ b/docs/mcq/interview_question/intermediate/exception-handling.md
@@ -1,18 +1,48 @@
 ---
-title: "C++ Interview Questions(Exception Handling)"
-description: "Prepare for C++ interviews with this guide to essential C++ interview questions on exception handling. Learn about try-catch blocks, exception hierarchy, custom exceptions, and best practices."
+id: CppInterviewQuestionsExceptionHandling
+title: C++ Interview Questions on Exception Handling
+description: |
+  This guide covers essential C++ interview questions on exception handling, an important feature in C++ for handling runtime errors and ensuring program stability. Learn how to use try, catch, throw, and custom exception classes. Understand exception safety, the types of exceptions, and how to properly manage exceptions in your C++ code to prevent crashes and undefined behavior. This guide will help you prepare for technical interviews focused on error handling and robust program design.
 keywords:
-- "C++ Interview Questions"
-- "C++ MCQ for Placement"
-- "C++ Exception Handling"
-- "C++ Try Catch"
-- "C++ Error Handling"
-- "C++ Custom Exceptions"
-- "Exception Safety in C++"
-- "C++ Standard Exceptions"
-- "C++ Exception Hierarchy"
-- "C++ Interview Guide"
-- "Master C++ Exception Handling Concepts"
+  - C++ Interview Questions
+  - Exception Handling in C++
+  - C++ Try Catch Block
+  - C++ Throw Statement
+  - C++ Custom Exceptions
+  - C++ Exception Safety
+  - C++ Exception Handling Best Practices
+  - C++ Exception Hierarchy
+  - C++ Standard Exception Class
+  - C++ Exception Handling Interview
+  - C++ Runtime Errors
+  - C++ Error Handling
+  - C++ Exception Types
+  - C++ Exception Handling Techniques
+  - C++ Throwing Exceptions
+  - C++ Catching Exceptions
+  - C++ Handling Multiple Exceptions
+  - C++ RAII in Exception Handling
+  - C++ Interview Preparation
+
+tags:
+  - C++ Interview Questions
+  - Exception Handling in C++
+  - C++ Try Catch
+  - C++ Throw Statement
+  - C++ Custom Exceptions
+  - C++ Exception Safety
+  - C++ Error Handling
+  - C++ Exception Hierarchy
+  - C++ Standard Exception Class
+  - C++ Exception Types
+  - C++ Exception Handling Techniques
+  - C++ Runtime Errors
+  - C++ Exception Handling Best Practices
+  - C++ RAII
+  - C++ Multiple Exceptions
+  - C++ Interview Preparation
+  - C++ Error Management
+
 ---
 
 # **Essential C++ Interview Questions on Exception Handling**

--- a/docs/mcq/interview_question/intermediate/inheritance-polymorphism.md
+++ b/docs/mcq/interview_question/intermediate/inheritance-polymorphism.md
@@ -1,18 +1,49 @@
 ---
-title: "C++ Interview Questions(Inheritance and Polymorphism)"
-description: "Prepare for C++ interviews with this guide to essential C++ interview questions on inheritance and polymorphism. Learn about base and derived classes, virtual functions, method overriding, and best practices."
+id: EssentialCppInterviewQuestionsInheritancePolymorphism
+title: Essential C++ Interview Questions on Inheritance and Polymorphism
+description: |
+  This guide covers essential C++ interview questions on inheritance and polymorphism, two of the core concepts of object-oriented programming (OOP). Learn about different types of inheritance (single, multiple, multilevel, hierarchical) and how polymorphism allows you to write flexible and reusable code. Understand the implementation of virtual functions, function overriding, and dynamic binding in C++ to prepare for technical interviews.
 keywords:
-- "C++ Interview Questions"
-- "C++ Inheritance"
-- "C++ MCQ for Placement"
-- "C++ Polymorphism"
-- "C++ Virtual Functions"
-- "C++ Method Overriding"
-- "C++ Abstract Classes"
-- "C++ Multiple Inheritance"
-- "C++ OOP Concepts"
-- "C++ Interview Guide"
-- "Master C++ Inheritance and Polymorphism"
+  - C++ Interview Questions
+  - Inheritance in C++
+  - Polymorphism in C++
+  - C++ Object-Oriented Programming
+  - C++ Inheritance Types
+  - Function Overriding in C++
+  - Virtual Functions in C++
+  - Dynamic Binding in C++
+  - C++ Base and Derived Classes
+  - C++ Access Specifiers
+  - C++ Virtual Destructor
+  - C++ Inheritance Hierarchy
+  - C++ Polymorphic Behavior
+  - C++ Overriding vs Overloading
+  - C++ Multiple Inheritance
+  - C++ Inheritance and Encapsulation
+  - C++ Inheritance in Classes
+  - C++ Interview Preparation
+
+tags:
+  - C++ Interview Questions
+  - Inheritance in C++
+  - Polymorphism in C++
+  - C++ Object-Oriented Programming
+  - C++ Function Overriding
+  - C++ Virtual Functions
+  - Dynamic Binding in C++
+  - C++ Inheritance Types
+  - C++ Multiple Inheritance
+  - C++ Virtual Destructor
+  - C++ Polymorphism
+  - C++ Base and Derived Classes
+  - C++ Access Specifiers
+  - C++ Inheritance Hierarchy
+  - C++ Overriding vs Overloading
+  - C++ Inheritance and Encapsulation
+  - C++ Object Design
+  - C++ Interview Preparation
+  - C++ Best Practices
+
 ---
 
 # **Essential C++ Interview Questions on Inheritance and Polymorphism**

--- a/docs/mcq/interview_question/intermediate/memory-management.md
+++ b/docs/mcq/interview_question/intermediate/memory-management.md
@@ -1,19 +1,48 @@
 ---
-title: "Essential C++ Interview Questions(Memory Management)"
-description: "Prepare for C++ interviews with this guide to essential C++ interview questions on memory management. Learn about dynamic memory allocation, smart pointers, memory leaks, and best practices."
+id: memory-management
+title: Essential C++ Interview Questions on Memory Management
+description: |
+  This guide focuses on essential C++ interview questions related to memory management. Learn about dynamic memory allocation, memory leaks, pointers, smart pointers, memory deallocation, and garbage collection in C++. These concepts are crucial for any C++ developer and are commonly tested in interviews. Prepare to answer questions on stack vs heap memory, memory optimization techniques, and more.
 keywords:
-- "C++ Interview Questions"
-- "C++ Memory Management"
-- "C++ MCQ for Placement"
-- "C++ Dynamic Allocation"
-- "C++ MCQ for Placement"
-- "C++ Smart Pointers"
-- "C++ Memory Leaks"
-- "C++ Heap vs Stack"
-- "C++ new and delete"
-- "C++ Best Practices"
-- "C++ Memory Optimization"
-- "Master C++ Memory Management Concepts"
+  - C++ Interview Questions
+  - Memory Management in C++
+  - C++ Pointers
+  - Dynamic Memory Allocation in C++
+  - Memory Deallocation
+  - C++ Memory Leaks
+  - C++ Smart Pointers
+  - C++ Stack and Heap
+  - C++ Memory Optimization
+  - C++ Garbage Collection
+  - C++ Memory Allocation
+  - C++ Memory Management Best Practices
+  - C++ Memory Management Interview
+  - C++ New and Delete Operators
+  - C++ Memory Pooling
+  - C++ Destructor and Destructor Calls
+  - C++ Memory Usage
+  - C++ Interview Preparation
+
+tags:
+  - C++ Interview Questions
+  - Memory Management in C++
+  - C++ Pointers
+  - Dynamic Memory Allocation
+  - C++ Memory Leaks
+  - C++ Smart Pointers
+  - Stack and Heap in C++
+  - C++ Memory Deallocation
+  - C++ Garbage Collection
+  - Memory Management Techniques
+  - C++ Memory Allocation
+  - C++ Memory Management Best Practices
+  - C++ Interview Preparation
+  - C++ New and Delete
+  - C++ Memory Optimization
+  - C++ Destructor Calls
+  - C++ Performance Optimization
+  - C++ Memory Pooling
+
 ---
 
 # **Essential C++ Interview Questions on Memory Management**

--- a/docs/mcq/interview_question/intermediate/oop.md
+++ b/docs/mcq/interview_question/intermediate/oop.md
@@ -1,18 +1,50 @@
 ---
-title: "Essential C++ Interview Questions on (Object-Oriented Programming)"
-description: "Prepare for C++ interviews with this guide to essential C++ interview questions on Object-Oriented Programming (OOP). Learn about classes, objects, inheritance, polymorphism, encapsulation, and abstraction."
+id: oop
+title: Essential C++ Interview Questions on Object-Oriented Programming (OOP)
+description: |
+  This guide covers essential C++ interview questions on Object-Oriented Programming (OOP). Understand the key OOP concepts like classes, objects, inheritance, polymorphism, abstraction, and encapsulation in C++. These concepts are fundamental to C++ programming and often come up in interviews. Prepare for questions on OOP principles, design patterns, and how they are implemented in C++ to write clean, maintainable, and scalable code.
 keywords:
-- "C++ Interview Questions"
-- "C++ MCQ for Placement"
-- "C++ Object-Oriented Programming"
-- "C++ OOP"
-- "C++ Classes and Objects"
-- "C++ Inheritance"
-- "C++ Polymorphism"
-- "C++ Encapsulation"
-- "C++ Abstraction"
-- "C++ Virtual Functions"
-- "Master C++ OOP Concepts"
+  - C++ Interview Questions
+  - Object-Oriented Programming in C++
+  - OOP Concepts in C++
+  - C++ Classes and Objects
+  - C++ Inheritance
+  - C++ Polymorphism
+  - C++ Abstraction
+  - C++ Encapsulation
+  - C++ Virtual Functions
+  - C++ Constructors and Destructors
+  - C++ Function Overloading
+  - C++ Operator Overloading
+  - C++ Design Patterns
+  - C++ Inheritance Types
+  - C++ Interfaces
+  - C++ Class Design
+  - C++ OOP Best Practices
+  - C++ Interview Preparation
+
+tags:
+  - C++ Interview Questions
+  - Object-Oriented Programming (OOP) in C++
+  - C++ Classes
+  - C++ Objects
+  - Inheritance in C++
+  - Polymorphism in C++
+  - Abstraction in C++
+  - Encapsulation in C++
+  - Virtual Functions in C++
+  - C++ Constructors and Destructors
+  - Function Overloading in C++
+  - Operator Overloading in C++
+  - C++ Design Patterns
+  - C++ Interfaces
+  - C++ Class Design
+  - C++ Best Practices
+  - OOP Principles in C++
+  - C++ Object Modeling
+  - C++ Performance Optimization
+  - C++ Interview Preparation
+
 ---
 
 # **Essential C++ Interview Questions on Object-Oriented Programming**

--- a/docs/mcq/interview_question/intermediate/operator-overloading.md
+++ b/docs/mcq/interview_question/intermediate/operator-overloading.md
@@ -1,18 +1,48 @@
 ---
-title: "Essential C++ Interview Questions(Operator Overloading)"
-description: "Prepare for C++ interviews with this guide to essential C++ interview questions on operator overloading. Learn how to overload operators, use friend functions, and implement best practices."
+id: operator-overloading
+title: Essential C++ Interview Questions on Operator Overloading
+description: |
+  This guide covers essential C++ interview questions on operator overloading, a key feature in C++ that allows you to define custom behavior for operators when applied to user-defined types. Learn how to overload operators such as +, -, *, and others to create intuitive and flexible C++ classes. Understand the rules, limitations, and best practices of operator overloading to be prepared for interview questions and practical scenarios.
 keywords:
-- "C++ Interview Questions"
-- "C++ MCQ for Placement"
-- "C++ Operator Overloading"
-- "C++ Overloaded Operators"
-- "C++ Friend Functions"
-- "C++ Operator Functions"
-- "C++ Custom Operators"
-- "C++ Unary and Binary Operators"
-- "C++ Operator Overloading Best Practices"
-- "C++ Interview Guide"
-- "Master C++ Operator Overloading"
+  - C++ Interview Questions
+  - Operator Overloading in C++
+  - Overloading Operators
+  - C++ Custom Operators
+  - C++ Operator Overloading Rules
+  - C++ Operator Functions
+  - Overloading + Operator in C++
+  - C++ Operator Overloading Best Practices
+  - C++ Binary Operators
+  - C++ Unary Operators
+  - C++ Operator Overloading Syntax
+  - C++ Operator Precedence
+  - C++ Operator Overloading with Classes
+  - C++ Friend Functions
+  - C++ Function Overloading
+  - C++ Operator Overloading Interview
+  - C++ Coding Standards
+  - C++ Interview Preparation
+
+tags:
+  - C++ Interview Questions
+  - Operator Overloading in C++
+  - Overloading Operators
+  - Custom Operators in C++
+  - C++ Operator Functions
+  - C++ Binary Operators
+  - C++ Unary Operators
+  - C++ Operator Overloading Rules
+  - C++ Best Practices
+  - C++ Friend Functions
+  - C++ Function Overloading
+  - C++ Operator Precedence
+  - C++ Interview Preparation
+  - C++ Coding Standards
+  - C++ Overloading + Operator
+  - C++ Overloading - Operator
+  - C++ Overloading * Operator
+  - C++ Operator Overloading Syntax
+
 ---
 
 # **Essential C++ Interview Questions on Operator Overloading**

--- a/docs/mcq/questions/advanced/concurrency.md
+++ b/docs/mcq/questions/advanced/concurrency.md
@@ -1,3 +1,50 @@
+---
+id: concurrency-and-synchronization
+title: Concurrency and Synchronization 
+description: |
+  This guide focuses on concurrency and synchronization, essential concepts for writing efficient multi-threaded programs. It covers topics like thread management, synchronization primitives such as mutexes, condition variables, and race conditions. Understanding these concepts is crucial for developing high-performance and thread-safe applications. Learn how to manage multiple threads, coordinate their execution, and avoid common pitfalls in concurrent programming.
+keywords:
+  - Concurrency
+  - Multi-threading
+  - Thread Management
+  - Mutex
+  - Condition Variables
+  - Race Conditions
+  - Thread Synchronization
+  - Synchronization Primitives
+  - Parallel Programming
+  - Thread Safety
+  - Atomic Operations
+  - Deadlock Prevention
+  - Locking Mechanisms
+  - Thread Pools
+  - Memory Models
+  - Parallel Algorithms
+  - Synchronization Techniques
+  - Thread Coordination
+  - Concurrent Programming
+
+tags:
+  - Concurrency
+  - Multi-threading
+  - Thread Management
+  - Mutex
+  - Condition Variables
+  - Synchronization
+  - Race Conditions
+  - Parallel Programming
+  - Thread Safety
+  - Deadlock
+  - Atomic Operations
+  - Locking
+  - Thread Pools
+  - Memory Models
+  - Parallel Algorithms
+  - Synchronization Primitives
+  - Thread Coordination
+  - Concurrent Programming Techniques
+
+---
 import { Question } from '../../Question';
 
 # Concurrency and Synchronization

--- a/docs/mcq/questions/advanced/cpp-features.md
+++ b/docs/mcq/questions/advanced/cpp-features.md
@@ -1,3 +1,51 @@
+---
+id: cpp-features-11-14-17-20
+title: C++11/14/17/20 Features
+description: |
+  Explore the powerful features introduced in the C++11, C++14, C++17, and C++20 standards. This guide covers the evolution of the language, from modernizing syntax and improving performance to adding powerful libraries and tools for developers. Learn about new data structures, concurrency features, lambda expressions, auto types, smart pointers, and more. Stay up-to-date with the best practices for using the most recent C++ standards in real-world applications.
+keywords:
+  - C++11 Features
+  - C++14 Features
+  - C++17 Features
+  - C++20 Features
+  - Modern C++ Syntax
+  - C++ Lambda Expressions
+  - C++ Auto Type
+  - Smart Pointers
+  - C++ Concurrency
+  - C++ Ranges
+  - C++ Modules
+  - C++ Templates
+  - C++ Type Inference
+  - C++ Standard Library
+  - C++ Algorithms
+  - C++ Language Evolution
+  - C++ Data Structures
+  - C++ Memory Management
+  - C++ Performance Optimization
+  - C++ Standardization
+
+tags:
+  - C++11
+  - C++14
+  - C++17
+  - C++20
+  - Modern C++
+  - C++ Syntax
+  - C++ Lambda
+  - C++ Auto
+  - Smart Pointers
+  - C++ Concurrency
+  - C++ Memory Management
+  - C++ Data Structures
+  - C++ Ranges
+  - C++ Templates
+  - Type Inference
+  - C++ Algorithms
+  - C++ Modules
+  - C++ Performance
+
+---
 import { Question } from '../../Question';
 
 # C++11/14/17/20 Features

--- a/docs/mcq/questions/advanced/exception-handling.md
+++ b/docs/mcq/questions/advanced/exception-handling.md
@@ -1,3 +1,46 @@
+---
+id: exception-handling
+title: Exception Handling
+description: |
+  Exception handling is a crucial concept in modern programming. This guide explores the mechanisms for managing runtime errors in a safe and controlled manner. Learn how to use `try`, `catch`, and `throw` to handle exceptions, define custom exception classes, and manage multiple exceptions. This topic is essential for writing robust, error-resistant applications.
+keywords:
+  - Exception Handling
+  - try-catch
+  - throw
+  - Custom Exceptions
+  - Error Handling
+  - Exception Classes
+  - Runtime Errors
+  - Exception Handling Mechanisms
+  - Exception Safety
+  - Error Management
+  - Exception Types
+  - Standard Exception
+  - try block
+  - catch block
+  - Exception Propagation
+  - noexcept
+  - Exception Handling Best Practices
+  - Exception Handling Techniques
+
+tags:
+  - Exception Handling
+  - try-catch
+  - throw
+  - Custom Exceptions
+  - Error Handling
+  - Runtime Errors
+  - Exception Classes
+  - Exception Propagation
+  - Exception Safety
+  - Error Management
+  - Exception Types
+  - Standard Exception
+  - Exception Handling Best Practices
+  - noexcept
+  - Robust Programming
+
+---
 import { Question } from '../../Question';
 
 # Exception Handling

--- a/docs/mcq/questions/advanced/lambdas.md
+++ b/docs/mcq/questions/advanced/lambdas.md
@@ -1,3 +1,41 @@
+---
+id: lambdas
+title: Lambda Functions
+description: |
+  Lambda functions are a powerful feature in modern programming, providing a concise way to define anonymous functions. This guide explores how to use lambda functions, capture variables from the surrounding scope, and pass them as arguments to other functions. Learn about lambda expressions, syntax, and the flexibility they offer in functional programming and other paradigms.
+keywords:
+  - Lambda Functions
+  - Anonymous Functions
+  - Functional Programming
+  - Lambda Expressions
+  - Function Objects
+  - Closures
+  - Variable Capture
+  - Higher-Order Functions
+  - Functional Techniques
+  - Lambda Syntax
+  - Lambda Parameters
+  - Immutable and Mutable Captures
+  - Lambda in Algorithms
+  - Lambda Expressions in Programming
+  - Functional Programming Techniques
+
+tags:
+  - Lambda Functions
+  - Anonymous Functions
+  - Functional Programming
+  - Lambda Expressions
+  - Closures
+  - Variable Capture
+  - Higher-Order Functions
+  - Function Objects
+  - Immutable Captures
+  - Mutable Captures
+  - Lambda Syntax
+  - Functional Programming Techniques
+  - Lambda Parameters
+
+---
 import { Question } from '../../Question';
 
 # Lambda Functions

--- a/docs/mcq/questions/advanced/move-semantics.md
+++ b/docs/mcq/questions/advanced/move-semantics.md
@@ -1,3 +1,45 @@
+---
+id: move-semantics
+title: Move Semantics and Rvalue References Multiple Choice Questions (MCQs)
+description: |
+  Test your understanding of move semantics and rvalue references in this set of Multiple Choice Questions (MCQs). Learn how move semantics enable efficient resource management by transferring ownership instead of copying, and understand the significance of rvalue references in modern programming. These MCQs cover topics such as move constructors, move assignment operators, and the use of `std::move`.
+keywords:
+  - Move Semantics
+  - Rvalue References
+  - Move Constructor
+  - Move Assignment Operator
+  - Resource Management
+  - Efficient Memory Management
+  - Rvalue References in Programming
+  - std::move
+  - C++ Move Semantics
+  - Memory Efficiency
+  - Move Semantics MCQs
+  - Rvalue References MCQs
+  - C++ Interview Questions
+  - Move Semantics Concepts
+  - Move Semantics in Modern Programming
+  - Move Semantics Test
+  - C++ Resource Transfer
+
+tags:
+  - Move Semantics
+  - Rvalue References
+  - Move Constructor
+  - Move Assignment Operator
+  - Resource Management
+  - Rvalue References in Programming
+  - std::move
+  - Memory Efficiency
+  - C++ Move Semantics
+  - Efficient Memory Management
+  - Move Semantics MCQs
+  - Rvalue References MCQs
+  - C++ Interview Questions
+  - Move Semantics Concepts
+  - Move Semantics in Modern Programming
+
+---
 import { Question } from '../../Question';
 
 # Move Semantics and Rvalue References

--- a/docs/mcq/questions/advanced/multithreading.md
+++ b/docs/mcq/questions/advanced/multithreading.md
@@ -1,3 +1,45 @@
+---
+id: multithreading
+title: Multi-threading Multiple Choice Questions (MCQs)
+description: |
+  Test your knowledge of multi-threading with this set of Multiple Choice Questions (MCQs). Learn about thread creation, synchronization, race conditions, thread safety, deadlock, and various concurrency mechanisms. These questions help reinforce your understanding of multi-threading concepts and their application in building efficient and thread-safe applications.
+keywords:
+  - Multi-threading
+  - Thread Creation
+  - Synchronization
+  - Thread Safety
+  - Deadlock
+  - Race Conditions
+  - Thread Pools
+  - Concurrency Mechanisms
+  - Synchronization Primitives
+  - Mutex
+  - Condition Variables
+  - Parallelism
+  - Multi-threading MCQs
+  - Concurrency Concepts
+  - Thread Management
+  - Parallel Programming
+  - Concurrency Test
+
+tags:
+  - Multi-threading
+  - Thread Creation
+  - Synchronization
+  - Thread Safety
+  - Deadlock
+  - Race Conditions
+  - Thread Pools
+  - Concurrency Mechanisms
+  - Mutex
+  - Condition Variables
+  - Parallelism
+  - Concurrency MCQs
+  - Thread Management
+  - Parallel Programming
+  - Concurrency Concepts
+
+---
 import { Question } from '../../Question';
 
 # Multi-threading

--- a/docs/mcq/questions/advanced/stl.md
+++ b/docs/mcq/questions/advanced/stl.md
@@ -1,3 +1,48 @@
+---
+id: stl
+title: "STL: Standard Template Library Multiple Choice Questions (MCQs)"
+description: "Test your understanding of the Standard Template Library (STL) in this set of Multiple Choice Questions (MCQs). This guide covers various components of STL including containers, iterators, algorithms, and function objects. Understand how to efficiently use data structures such as vectors, maps, and sets, as well as how STL provides powerful algorithms for sorting, searching, and modifying data."
+
+keywords:
+  - STL
+  - Standard Template Library
+  - C++ Containers
+  - C++ Iterators
+  - C++ Algorithms
+  - C++ Function Objects
+  - C++ Vectors
+  - C++ Maps
+  - C++ Sets
+  - C++ Lists
+  - C++ Stacks
+  - C++ Queues
+  - C++ Pair
+  - C++ Algorithm Functions
+  - STL Containers MCQs
+  - STL Iterators MCQs
+  - STL Algorithms MCQs
+  - STL Function Objects MCQs
+
+tags:
+  - STL
+  - Standard Template Library
+  - C++ Containers
+  - C++ Iterators
+  - C++ Algorithms
+  - C++ Function Objects
+  - Vectors
+  - Maps
+  - Sets
+  - Lists
+  - Stacks
+  - Queues
+  - Pair
+  - Algorithm Functions
+  - STL MCQs
+  - C++ Data Structures
+  - STL Concepts
+
+---
 import { Question } from '../../Question';
 
 # STL: Standard Template Library

--- a/docs/mcq/questions/advanced/templates.md
+++ b/docs/mcq/questions/advanced/templates.md
@@ -1,3 +1,46 @@
+---
+id: templates
+title: Templates Multiple Choice Questions (MCQs)
+description: |
+  Test your knowledge of templates in programming with this set of Multiple Choice Questions (MCQs). This guide covers function templates, class templates, template specialization, and template metaprogramming. Learn how templates provide flexibility and code reuse in your programs, and understand the benefits of generic programming.
+keywords:
+  - Templates
+  - Function Templates
+  - Class Templates
+  - Template Specialization
+  - Template Metaprogramming
+  - C++ Templates
+  - Generic Programming
+  - Type Deduction
+  - Template Arguments
+  - Template Parameters
+  - Template Instantiation
+  - SFINAE (Substitution Failure Is Not An Error)
+  - Variadic Templates
+  - Template Functions
+  - Template Classes
+  - Template MCQs
+  - Template Knowledge Test
+
+tags:
+  - Templates
+  - Function Templates
+  - Class Templates
+  - Template Specialization
+  - Template Metaprogramming
+  - C++ Templates
+  - Generic Programming
+  - Type Deduction
+  - Template Parameters
+  - Template Instantiation
+  - SFINAE
+  - Variadic Templates
+  - Template Functions
+  - Template Classes
+  - Template MCQs
+  - Template Concepts
+
+---
 import { Question } from '../../Question';
 
 # Templates

--- a/docs/mcq/questions/advanced/vectors.md
+++ b/docs/mcq/questions/advanced/vectors.md
@@ -1,3 +1,45 @@
+---
+id: vectors
+title: Vectors and Dynamic Arrays Multiple Choice Questions (MCQs)
+description: |
+  Test your knowledge of vectors and dynamic arrays with this set of Multiple Choice Questions (MCQs). Learn how vectors provide dynamic resizing of arrays, manage memory automatically, and offer various functions to manipulate and access data. Understand how dynamic arrays work and how they differ from static arrays, offering flexibility in memory management.
+keywords:
+  - Vectors
+  - Dynamic Arrays
+  - C++ Vectors
+  - Dynamic Memory Allocation
+  - Memory Management
+  - Array vs Vector
+  - Dynamic Array Operations
+  - Vector Operations
+  - C++ Array Functions
+  - C++ Vector Functions
+  - Array Resizing
+  - Dynamic Array Size
+  - C++ Containers
+  - Vector Memory Management
+  - C++ Memory Management
+  - Vector vs Array
+  - Vectors MCQs
+  - Dynamic Arrays MCQs
+
+tags:
+  - Vectors
+  - Dynamic Arrays
+  - C++ Vectors
+  - Dynamic Memory Allocation
+  - Memory Management
+  - Vector Operations
+  - Array Resizing
+  - C++ Arrays
+  - Dynamic Array Functions
+  - C++ Containers
+  - Vector Functions
+  - C++ Memory Management
+  - Vectors MCQs
+  - Dynamic Arrays MCQs
+
+---
 import { Question } from '../../Question';
 
 # Vectors and Dynamic Arrays

--- a/docs/mcq/questions/basic/array-and-strings.md
+++ b/docs/mcq/questions/basic/array-and-strings.md
@@ -1,24 +1,50 @@
 ---
-title: Array and String C++ Learning Guide
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+id: array-and-strings
+title: Array and String MCQs
+description: |
+  This guide covers the fundamentals and advanced techniques for working with arrays and strings in C++. Learn how to manipulate fixed-size arrays, dynamic arrays, and C-style strings, as well as leverage the power of `std::array`, `std::vector`, and `std::string` for safer, more efficient coding. Ideal for beginners and intermediates preparing for interviews or building foundational logic.
+keywords:
+  - Arrays in C++
+  - Strings in C++
+  - std::array C++
+  - std::vector C++
+  - std::string C++
+  - Dynamic Arrays in C++
+  - Fixed Size Arrays
+  - C-style Strings
+  - Character Arrays
+  - C++ String Functions
+  - Array Manipulation
+  - String Reversal C++
+  - Palindrome Check C++
+  - Substrings in C++
+  - Two-Pointer Technique
+  - C++ Interview Questions
+  - Basic Data Structures in C++
+  - String Matching Algorithms
+  - String to Integer Conversion
+  - C++ Practice Problems
+
+tags:
+  - Arrays
+  - Strings
+  - C++ Vectors
+  - std::array
+  - std::string
+  - Dynamic Memory
+  - C++ Basics
+  - String Algorithms
+  - C++ Interview Prep
+  - Data Structures
+  - C-style Strings
+  - Array Operations
+  - Substrings
+  - Character Arrays
+  - Two-Pointer Technique
+  - Coding Practice
+  - Beginner C++
+  - Intermediate C++
+
 ---
 import { Question } from '../../Question';  // Adjust the path to your Question.js component
 

--- a/docs/mcq/questions/basic/basic.md
+++ b/docs/mcq/questions/basic/basic.md
@@ -1,25 +1,47 @@
 ---
 id: basic
 title: Basic C++ Learning Guide
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+description: |
+  Start your journey into C++ with this basic learning guide. Covering fundamental topics such as data types, operators, control flow, functions, and object-oriented programming, this guide provides a solid foundation for anyone new to programming or transitioning to C++. It's designed for beginners who want to grasp core C++ concepts and start building simple programs quickly.
+keywords:
+  - C++ Basics
+  - C++ for Beginners
+  - Data Types in C++
+  - C++ Operators
+  - Control Flow in C++
+  - Functions in C++
+  - Object-Oriented Programming C++
+  - C++ Loops
+  - Conditional Statements C++
+  - Arrays in C++
+  - C++ Syntax
+  - Introduction to C++
+  - C++ Variables
+  - C++ Operators and Expressions
+  - C++ Program Structure
+  - C++ Functions and Methods
+  - Beginner C++ Tutorials
+  - Simple C++ Programs
+  - First C++ Program
+
+tags:
+  - C++ Basics
+  - Beginner C++
+  - Data Types
+  - C++ Operators
+  - Control Flow
+  - Loops in C++
+  - Conditional Statements
+  - Functions in C++
+  - OOP Basics
+  - C++ Syntax
+  - Arrays
+  - C++ for Beginners
+  - Intro to C++
+  - C++ Program Structure
+  - Learning C++ Step-by-Step
+  - C++ Programming Fundamentals
+
 ---
 
 # Learning Basic C++
@@ -41,7 +63,7 @@ Welcome to the journey of learning C++! Here are some key topics that will help 
 5. **[Arrays and Strings](array-and-strings.md)**  
    Explore arrays and strings, which are essential for handling collections of data in C++.
 
-6. **[Pointers and Strings](pointers-strings.md)**  
+6. [Pointers and Strings](pointers-strings.md)**  
    Understand pointers in C++ and how they relate to memory management, as well as how to manipulate strings.
 
 7. **[Control Flow](control-flow.md)**  

--- a/docs/mcq/questions/basic/control-flow.md
+++ b/docs/mcq/questions/basic/control-flow.md
@@ -1,26 +1,48 @@
 ---
-title: Control Flow C++ MCQ
-keywords: 
-- C++
-- learning C++ 
-- basics
-- control statement
-- if else
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+id: control-flow
+title: Control Flow C++ Multiple Choice Questions (MCQs)
+description: |
+  This collection of C++ Multiple Choice Questions (MCQs) focuses on control flow concepts, including loops, conditional statements, branching, and decision-making. Perfect for beginners and intermediate learners to test their knowledge on essential C++ control structures such as `if-else`, `switch`, `for`, `while`, and `do-while` loops.
+keywords:
+  - C++ Control Flow
+  - C++ Loops
+  - C++ Conditional Statements
+  - C++ Decision Making
+  - C++ Branching
+  - If-Else in C++
+  - Switch Statement in C++
+  - For Loop in C++
+  - While Loop in C++
+  - Do-While Loop in C++
+  - C++ MCQs
+  - C++ Quiz
+  - C++ Interview Questions
+  - C++ Syntax
+  - Flow Control C++
+  - C++ Basics Quiz
+  - C++ Programming Test
+  - C++ Exam Questions
+  - C++ Testing
+
+tags:
+  - Control Flow
+  - C++ Loops
+  - Conditional Statements
+  - C++ MCQs
+  - C++ Test
+  - C++ Interview Questions
+  - Programming Quiz
+  - C++ Syntax
+  - C++ Quiz Questions
+  - C++ Beginners
+  - C++ Practice
+  - C++ For Loop
+  - C++ While Loop
+  - C++ Decision Making
+  - C++ Switch Statement
+  - C++ Programming Challenge
+  - C++ Testing and Practice
+
 ---
 import { Question } from '../../Question';  // Adjust the path to your Question.js component
 

--- a/docs/mcq/questions/basic/data-types.md
+++ b/docs/mcq/questions/basic/data-types.md
@@ -1,24 +1,48 @@
 ---
-title: Data Type C++ MCQ
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+id: data-types
+title: Data Type C++ Multiple Choice Questions (MCQs)
+description: |
+  This collection of C++ Multiple Choice Questions (MCQs) covers fundamental data types in C++, including `int`, `char`, `float`, `double`, `bool`, and user-defined types like `struct`, `union`, and `enum`. It also touches on type conversions, pointers, and references, making it ideal for beginners and intermediate learners to test their knowledge on C++ data handling.
+keywords:
+  - C++ Data Types
+  - C++ MCQs
+  - C++ Primitive Data Types
+  - C++ int
+  - C++ char
+  - C++ float
+  - C++ double
+  - C++ bool
+  - C++ struct
+  - C++ union
+  - C++ enum
+  - Type Conversion in C++
+  - C++ Pointers and References
+  - C++ Type Modifiers
+  - C++ Data Handling
+  - C++ Data Storage
+  - C++ Memory Allocation
+  - C++ Variable Types
+  - C++ Interview Questions
+
+tags:
+  - C++ Data Types
+  - C++ MCQs
+  - Primitive Data Types
+  - C++ Quiz
+  - C++ Interview Questions
+  - Data Handling in C++
+  - C++ int
+  - C++ char
+  - C++ float
+  - C++ double
+  - C++ bool
+  - C++ Structs and Unions
+  - Type Conversion
+  - C++ Type Modifiers
+  - C++ Memory Management
+  - C++ Variable Types
+  - C++ Reference Types
+
 ---
 import { Question } from '../../Question';  // Adjust the path to your Question.js component
 

--- a/docs/mcq/questions/basic/functions.md
+++ b/docs/mcq/questions/basic/functions.md
@@ -1,24 +1,44 @@
 ---
-title: Functions in C++ MCQs
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- fuctions in C++
+id: functions
+title: Functions in C++ Multiple Choice Questions (MCQs)
+description: |
+  This set of C++ Multiple Choice Questions (MCQs) focuses on functions in C++, covering function declarations, definitions, arguments, return types, and various advanced topics such as recursion, function overloading, and inline functions. Ideal for learners to test their understanding of C++ function fundamentals and advanced usage.
+keywords:
+  - C++ Functions
+  - Function Declaration in C++
+  - Function Definition in C++
+  - Function Overloading in C++
+  - Inline Functions in C++
+  - C++ Recursion
+  - C++ Function Pointers
+  - Return Types in C++
+  - C++ Argument Passing
+  - C++ Variable Arguments
+  - C++ Function Templates
+  - C++ Call by Value
+  - C++ Call by Reference
+  - C++ Function Scope
+  - C++ Lambda Functions
+  - C++ Interview Questions
+  - C++ MCQs
+
+tags:
+  - C++ Functions
+  - Function Overloading
+  - C++ Recursion
+  - Function Pointers
+  - Inline Functions
+  - C++ MCQs
+  - C++ Call by Value
+  - C++ Call by Reference
+  - C++ Argument Passing
+  - Variable Arguments in C++
+  - C++ Function Templates
+  - C++ Lambda Expressions
+  - C++ Interview Questions
+  - Function Scope in C++
+  - C++ Programming Challenges
+
 ---
 
 import { Question } from '../../Question';  // Adjust the path to your Question.js component

--- a/docs/mcq/questions/basic/intro-to-cpp.md
+++ b/docs/mcq/questions/basic/intro-to-cpp.md
@@ -1,24 +1,45 @@
 ---
+id: intro-to-cpp
 title: Basic C++ MCQ
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+description: |
+  Test your knowledge of basic C++ concepts with this set of multiple choice questions (MCQs). Covering topics like variables, functions, pointers, control flow, and loops, this quiz is designed for beginners and those preparing for C++ interviews. A great way to assess your understanding of fundamental C++ programming concepts and prepare for real-world challenges.
+keywords:
+  - C++
+  - learning C++
+  - basics
+  - cpp mcq
+  - cpp mcq questions
+  - cpp interview questions
+  - c++ mcq
+  - advanced c++ interview questions
+  - c++ mcq questions and answers
+  - C++ programming
+  - cpp mcqs
+  - mcq in c++
+  - variables
+  - functions
+  - c++ mcq test
+  - pointers
+  - control flow
+  - loops
+
+tags:
+  - C++ Basics
+  - C++ MCQs
+  - C++ Interview Questions
+  - Programming Quiz
+  - C++ Functions
+  - C++ Variables
+  - C++ Pointers
+  - Control Flow in C++
+  - C++ Loops
+  - Beginner C++
+  - C++ Programming Test
+  - C++ Syntax
+  - C++ Coding Challenge
+  - Learning C++
+  - C++ Programming Fundamentals
+
 ---
 
 import { Question } from '../../Question';  // Adjust the path to your Question.js component

--- a/docs/mcq/questions/basic/io.md
+++ b/docs/mcq/questions/basic/io.md
@@ -1,24 +1,48 @@
 ---
-title: Input Output C++ MCQs
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+id: io
+title: Input Output C++ Multiple Choice Questions (MCQs)
+description: |
+  Test your knowledge on C++ Input and Output operations with this set of Multiple Choice Questions (MCQs). The questions cover topics like `cin`, `cout`, file handling, streams, and error handling, essential for any C++ programmer. Ideal for beginners and those preparing for C++ interviews, this quiz will help you strengthen your understanding of I/O operations in C++.
+keywords:
+  - C++ Input and Output
+  - C++ cin
+  - C++ cout
+  - C++ File Handling
+  - C++ Streams
+  - C++ Input
+  - C++ Output
+  - C++ Error Handling
+  - C++ I/O Operations
+  - C++ MCQs
+  - C++ Interview Questions
+  - C++ Programming
+  - C++ Input-Output Quiz
+  - C++ File Streams
+  - C++ I/O Functions
+  - C++ Stream Manipulators
+  - C++ I/O Techniques
+  - C++ Text File Handling
+  - C++ Binary File Handling
+
+tags:
+  - C++ Input and Output
+  - C++ MCQs
+  - C++ File Handling
+  - C++ Streams
+  - cin and cout
+  - C++ File Streams
+  - C++ Error Handling
+  - C++ I/O Functions
+  - C++ Interview Questions
+  - Programming Quiz
+  - C++ Input
+  - C++ Output
+  - C++ Text File Handling
+  - C++ Binary Files
+  - Stream Manipulators
+  - Beginner C++
+  - C++ Programming Fundamentals
+
 ---
 
 import { Question } from '../../Question';  // Adjust the path to your Question.js component

--- a/docs/mcq/questions/basic/loop.md
+++ b/docs/mcq/questions/basic/loop.md
@@ -1,24 +1,45 @@
 ---
-title: Loop C++ Learning Guide
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+id: loop
+title: Loop C++ Multiple Choice Questions (MCQs)
+description: |
+  This set of C++ Multiple Choice Questions (MCQs) focuses on loops in C++. Test your knowledge on `for`, `while`, `do-while`, nested loops, and loop control statements like `break`, `continue`, and `return`. Whether you're a beginner or preparing for a C++ interview, these questions will help reinforce your understanding of loop structures in C++.
+keywords:
+  - C++ Loops
+  - C++ for loop
+  - C++ while loop
+  - C++ do-while loop
+  - Nested Loops in C++
+  - Loop Control Statements
+  - C++ break statement
+  - C++ continue statement
+  - Looping in C++
+  - C++ MCQs
+  - C++ Interview Questions
+  - C++ Programming
+  - Looping Constructs
+  - C++ Looping Techniques
+  - C++ Exam Questions
+  - C++ Quiz
+  - C++ Coding Challenges
+
+tags:
+  - C++ Loops
+  - C++ for loop
+  - C++ while loop
+  - C++ do-while loop
+  - Loop Control
+  - Nested Loops
+  - C++ MCQs
+  - C++ Interview Questions
+  - C++ Break and Continue
+  - C++ Programming
+  - Loop Structures
+  - Looping Constructs
+  - C++ Quiz
+  - C++ Exam Questions
+  - C++ Coding Practice
+  - C++ Loop Techniques
+
 ---
 
 import { Question } from '../../Question';  // Adjust the path based on your project structure

--- a/docs/mcq/questions/basic/pointers-and-references.md
+++ b/docs/mcq/questions/basic/pointers-and-references.md
@@ -1,0 +1,8 @@
+# 🚧 Coming Soon
+
+Exciting content is on the way! We’re working hard to bring you in-depth guides, tutorials, and insights.
+
+Stay ahead of the curve —  
+<a href="https://compilersutra.com/newsletter">
+  📬 Subscribe Now
+</a>

--- a/docs/mcq/questions/basic/pointers-strings.md
+++ b/docs/mcq/questions/basic/pointers-strings.md
@@ -1,28 +1,46 @@
 ---
-title: Pointer and String C++ Learning Guide
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcq questions
-- c++ quiz question with answers
-- mcq for c++
-- c++ mcq online test with answer
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+id: pointers-strings
+title: Pointer and String C++ Multiple Choice Questions (MCQs)
+description: |
+  Test your knowledge of pointers and strings in C++ with this set of Multiple Choice Questions (MCQs). This quiz covers topics such as pointer arithmetic, dynamic memory allocation, pointer-to-pointer, and string manipulation in C++. It is ideal for beginners and those preparing for C++ interviews, helping you solidify your understanding of two key concepts in C++ programming.
+keywords:
+  - C++ Pointers
+  - C++ Strings
+  - Pointer Arithmetic
+  - Dynamic Memory Allocation
+  - Pointer-to-Pointer in C++
+  - C++ String Manipulation
+  - C++ String Functions
+  - C++ Memory Management
+  - C++ String Handling
+  - C++ MCQs
+  - C++ Interview Questions
+  - C++ Pointer Concepts
+  - C++ String Methods
+  - C++ Programming
+  - C++ Pointers and Arrays
+  - C++ Char Arrays
+  - C++ Pointer to Array
+  - String Manipulation C++
+
+tags:
+  - C++ Pointers
+  - C++ Strings
+  - Pointer Arithmetic
+  - Dynamic Memory Allocation
+  - Pointer-to-Pointer
+  - C++ String Functions
+  - C++ String Handling
+  - C++ MCQs
+  - C++ Interview Questions
+  - C++ Memory Management
+  - C++ Char Arrays
+  - String Manipulation in C++
+  - C++ Programming
+  - C++ Arrays and Pointers
+  - C++ Pointer Basics
+  - C++ String Manipulation Techniques
+
 ---
 import { Question } from '../../Question';  // Adjust the path to your Question.js component
 

--- a/docs/mcq/questions/basic/variables-and-constants.md
+++ b/docs/mcq/questions/basic/variables-and-constants.md
@@ -1,24 +1,47 @@
 ---
-title: Variable and Constant C++ Learning Guide
-keywords: 
-- C++
-- learning C++ 
-- basics
-- cpp mcq
-- cpp mcq questions
-- cpp interview questions
-- c++ mcq
-- advanced c++ interview questions
-- c++ mcq questions and answers
-- C++ programming
-- cpp mcqs
-- mcq in c++
-- variables
-- functions
-- c++ mcq test
-- pointers
-- control flow
-- loops
+id: variables-and-constants
+title: Variable and Constant C++ Multiple Choice Questions (MCQs)
+description: |
+  Test your knowledge of variables and constants in C++ with this set of Multiple Choice Questions (MCQs). This quiz covers topics such as variable types, initialization, constant variables, and scope. It’s perfect for beginners who want to understand variable declaration, initialization, and how constants work in C++. Also useful for those preparing for C++ interviews to strengthen foundational knowledge.
+keywords:
+  - C++ Variables
+  - C++ Constants
+  - Variable Declaration in C++
+  - Constant Variables in C++
+  - C++ Initialization
+  - C++ Scope of Variables
+  - C++ const Keyword
+  - C++ Variable Types
+  - C++ const int
+  - C++ Constant Expressions
+  - C++ Programming Basics
+  - C++ MCQs
+  - C++ Interview Questions
+  - C++ Variable Scope
+  - C++ const Keyword Usage
+  - C++ Data Types
+  - C++ Variable Naming
+  - C++ Const Pointers
+
+tags:
+  - C++ Variables
+  - C++ Constants
+  - Variable Declaration
+  - Constant Variables
+  - C++ const Keyword
+  - C++ Variable Types
+  - C++ Initialization
+  - Variable Scope
+  - C++ const int
+  - C++ Programming Fundamentals
+  - C++ MCQs
+  - C++ Interview Questions
+  - C++ Data Types
+  - Constant Expressions
+  - C++ Basic Programming
+  - C++ Variable Naming Conventions
+  - C++ Scope of Variables
+
 ---
 import { Question } from '../../Question';  // Adjust the path to your Question.js component
 

--- a/docs/mcq/questions/intermediate/constructors-destructors.md
+++ b/docs/mcq/questions/intermediate/constructors-destructors.md
@@ -127,3 +127,103 @@ import { Question } from '../../Question';
   options={['When an object goes out of scope', 'When a new object is created', 'When a constructor is called', 'None of the above']}
   answer="When an object goes out of scope"
 />
+<Question
+  question="11).Can a constructor be declared as virtual in C++?"
+  options={['Yes', 'No', 'Only in abstract classes', 'Depends on the compiler']}
+  answer="No"
+/>
+<Question
+  question="12).What is constructor overloading?"
+  options={['Using different names for multiple constructors', 'Having multiple constructors with different parameter lists', 'Creating virtual constructors', 'None of the above']}
+  answer="Having multiple constructors with different parameter lists"
+/>
+<Question
+  question="13).Which constructor is invoked when an object is initialized using another object?"
+  options={['Default constructor', 'Parameterized constructor', 'Copy constructor', 'Move constructor']}
+  answer="Copy constructor"
+/>
+<Question
+  question="14).Which constructor is called when an object is initialized with `std::move()`?"
+  options={['Default constructor', 'Copy constructor', 'Move constructor', 'None']}
+  answer="Move constructor"
+/>
+<Question
+  question="15).Which keyword is used to define a constructor outside the class?"
+  options={['this', 'new', '::', 'extern']}
+  answer="::"
+/>
+<Question
+  question="16).What is a parameterized constructor?"
+  options={['A constructor that takes arguments', 'A constructor with no parameters', 'A constructor with a return type', 'None of the above']}
+  answer="A constructor that takes arguments"
+/>
+<Question
+  question="17).Can a constructor be private in C++?"
+  options={['Yes', 'No', 'Only for abstract classes', 'Only for static classes']}
+  answer="Yes"
+/>
+<Question
+  question="18).When is the copy constructor called?"
+  options={['When an object is passed by value', 'When an object is returned by value', 'When an object is explicitly copied', 'All of the above']}
+  answer="All of the above"
+/>
+<Question
+  question="19).Which of the following does NOT invoke the destructor?"
+  options={['Object goes out of scope', 'delete is used on object pointer', 'Program crashes', 'Object is created']}
+  answer="Object is created"
+/>
+<Question
+  question="20).What happens if you don’t define a destructor in your class?"
+  options={['Compiler provides a default destructor', 'Objects cannot be destroyed', 'It causes a runtime error', 'None of the above']}
+  answer="Compiler provides a default destructor"
+/>
+<Question
+  question="21).Can you explicitly call a destructor?"
+  options={['Yes, using object.~ClassName()', 'No, destructors are always implicit', 'Only for static objects', 'None of the above']}
+  answer="Yes, using object.~ClassName()"
+/>
+<Question
+  question="22).Which constructor is invoked when no arguments are passed during object creation?"
+  options={['Copy constructor', 'Default constructor', 'Move constructor', 'Destructor']}
+  answer="Default constructor"
+/>
+<Question
+  question="23).Can a class have both a copy and a move constructor?"
+  options={['Yes', 'No', 'Only one is allowed', 'Depends on object type']}
+  answer="Yes"
+/>
+<Question
+  question="24).What does the compiler do if you define a copy constructor but not a destructor?"
+  options={['Generates a default destructor', 'Throws a compile-time error', 'Deletes the destructor', 'Generates a move constructor automatically']}
+  answer="Generates a default destructor"
+/>
+<Question
+  question="25).What is the syntax for a move constructor?"
+  options={['ClassName(ClassName&& obj)', 'ClassName(const ClassName& obj)', 'ClassName(ClassName obj)', 'ClassName(ClassName* obj)']}
+  answer="ClassName(ClassName&& obj)"
+/>
+<Question
+  question="26).What is the rule of three in C++?"
+  options={['Define copy constructor, assignment operator, and destructor together', 'Use only three constructors', 'Only three objects allowed in a class', 'None of the above']}
+  answer="Define copy constructor, assignment operator, and destructor together"
+/>
+<Question
+  question="27).Which of the following best describes constructor initialization list?"
+  options={['Initializes data members before constructor body executes', 'Is used for destructors', 'Used to create arrays', 'None of the above']}
+  answer="Initializes data members before constructor body executes"
+/>
+<Question
+  question="28).Which operator is implicitly deleted if a class has a move constructor but not a copy constructor?"
+  options={['Copy assignment operator', 'Destructor', 'Default constructor', 'New operator']}
+  answer="Copy assignment operator"
+/>
+<Question
+  question="29).What happens when you assign one object to another after creation?"
+  options={['Copy assignment operator is called', 'Copy constructor is called', 'Move constructor is called', 'Destructor is called']}
+  answer="Copy assignment operator"
+/>
+<Question
+  question="30).Can destructors be overloaded in C++?"
+  options={['Yes', 'No', 'Only with templates', 'Only in base classes']}
+  answer="No"
+/>

--- a/docs/mcq/questions/intermediate/intermediate.md
+++ b/docs/mcq/questions/intermediate/intermediate.md
@@ -1,22 +1,39 @@
 ---
-title: "Getting Started with OOPS Concept"
-description: "A comprehensive guide to resources, books, tutorials, and tools for beginners in compiler development, C++, GPU programming, MLIR, and machine learning."
-keywords: 
-  - compiler development
-  - C++ programming
-  - GPU programming
-  - MLIR
-  - machine learning
-  - compiler optimization
-  - online resources
-  - tutorials
-  - cpp mcq
-  - cpp mcq questions
-  - cpp interview questions
-  - c++ mcq
-  - advanced c++ interview questions
-  - LLVM
-  - education
+id: getting-started-with-oops-concept
+title: Getting Started with OOPS Concept
+description: |
+  This beginner-friendly guide introduces the fundamental concepts of Object-Oriented Programming (OOP) in C++. Learn the four core principles—encapsulation, abstraction, inheritance, and polymorphism—through real-world examples and C++ implementations. Whether you're new to OOP or revisiting the basics, this is the perfect place to start your object-oriented journey.
+keywords:
+  - Object-Oriented Programming in C++
+  - OOP Concepts
+  - C++ Classes and Objects
+  - Encapsulation in C++
+  - Inheritance in C++
+  - Polymorphism in C++
+  - Abstraction in C++
+  - C++ OOP Examples
+  - C++ Object-Oriented Basics
+  - C++ for Beginners
+  - Introduction to OOP
+  - OOP Fundamentals
+  - OOP in Programming
+  - C++ Class Design
+  - C++ Object-Oriented Approach
+
+tags:
+  - OOP in C++
+  - Encapsulation
+  - Abstraction
+  - Inheritance
+  - Polymorphism
+  - C++ Basics
+  - Object-Oriented Design
+  - Classes and Objects
+  - C++ OOP Examples
+  - Programming Fundamentals
+  - C++ for Beginners
+  - OOPS Concept Tutorial
+
 ---
 
 # Intermediate C++ Concepts

--- a/docs/mcq/questions/questions.md
+++ b/docs/mcq/questions/questions.md
@@ -1,16 +1,51 @@
 ---
-id: advanced-questions
-title: Advanced C++ Questions
+id: AdvancedCppInterviewQuestions
+title: Advanced C++ Interview Questions
+description: |
+  This guide contains a curated set of advanced C++ interview questions that challenge your understanding of high-level concepts in modern C++. Topics include smart pointers, move semantics, perfect forwarding, multi-threading, memory models, templates, STL internals, and advanced object-oriented and functional programming features. Ideal for experienced developers preparing for senior-level technical interviews.
 keywords:
-  - C++
-  - advanced C++
-  - concurrency
-  - lambdas
-  - multithreading
-  - templates
-  - STL
-  - move semantics
-  - exception handling
+  - Advanced C++ Interview Questions
+  - Modern C++
+  - C++11 C++14 C++17 C++20
+  - Smart Pointers in C++
+  - Move Semantics
+  - Rvalue References
+  - Perfect Forwarding
+  - Lambda Expressions
+  - C++ Multi-threading
+  - C++ Memory Model
+  - Template Metaprogramming
+  - STL Internals
+  - C++ Design Patterns
+  - C++ Virtual Tables
+  - Function Objects
+  - Advanced Object-Oriented Concepts
+  - Functional Programming in C++
+  - C++ Type Traits
+  - Compile-Time Computation
+  - C++ Performance Optimization
+
+tags:
+  - Advanced C++
+  - C++11/14/17/20
+  - Smart Pointers
+  - Move Semantics
+  - Rvalue References
+  - Perfect Forwarding
+  - Lambda Functions
+  - C++ Concurrency
+  - C++ Memory Model
+  - STL Internals
+  - Template Metaprogramming
+  - Design Patterns in C++
+  - C++ Type Traits
+  - Compile-Time Programming
+  - Functional C++
+  - VTables and Polymorphism
+  - Senior C++ Interviews
+  - Performance Optimization
+  - Advanced OOP in C++
+
 ---
 
 # Advanced C++ Topics

--- a/docs/mcq/questions/specialized/algorithm.md
+++ b/docs/mcq/questions/specialized/algorithm.md
@@ -1,3 +1,50 @@
+---
+id: algorithm
+title: C++ and Algorithms
+description: |
+  This guide explores the use of C++ for implementing a wide range of algorithms, from basic sorting and searching to advanced graph, dynamic programming, and greedy techniques. Understand how the Standard Template Library (STL) supports algorithm development and boosts performance. Ideal for coding interview prep, competitive programming, and building a strong foundation in problem-solving using C++.
+keywords:
+  - Algorithms in C++
+  - C++ STL Algorithms
+  - C++ Sorting Algorithms
+  - C++ Searching Algorithms
+  - Graph Algorithms in C++
+  - Dynamic Programming in C++
+  - C++ Greedy Algorithms
+  - C++ Backtracking
+  - Recursion in C++
+  - C++ Competitive Programming
+  - C++ Interview Prep
+  - Algorithm Design in C++
+  - Time Complexity in C++
+  - C++ Problem Solving
+  - STL Functions
+  - Binary Search C++
+  - Merge Sort C++
+  - Dijkstra Algorithm C++
+  - C++ Algorithm Techniques
+
+tags:
+  - C++ Algorithms
+  - STL Algorithms
+  - Sorting and Searching
+  - Graph Algorithms
+  - Dynamic Programming
+  - Greedy Algorithms
+  - Backtracking
+  - Recursion
+  - C++ STL
+  - Competitive Programming
+  - C++ Problem Solving
+  - Time and Space Complexity
+  - C++ Interview Preparation
+  - Algorithm Optimization
+  - Data Structures and Algorithms
+  - Binary Search
+  - C++ Coding Challenges
+  - Algorithm Techniques
+
+---
 import { Question } from '../../Question';
 
 # C++ and Algorithms

--- a/docs/mcq/questions/specialized/cpp-embedded.md
+++ b/docs/mcq/questions/specialized/cpp-embedded.md
@@ -1,3 +1,52 @@
+---
+id: cpp-embedded
+title: C++ for Embedded Systems
+description: |
+  This guide introduces the use of C++ in embedded systems programming, focusing on low-level hardware control, memory optimization, and real-time performance. Learn how to apply object-oriented principles in resource-constrained environments, understand embedded-specific C++ features, and explore best practices for writing efficient, portable, and maintainable firmware using C++.
+keywords:
+  - C++ for Embedded Systems
+  - Embedded C++
+  - Embedded Firmware Development
+  - Low-Level Programming in C++
+  - Memory Optimization in C++
+  - C++ Microcontrollers
+  - Real-Time Systems in C++
+  - Object-Oriented Embedded Programming
+  - Embedded C++ Best Practices
+  - Hardware Control in C++
+  - Interrupt Handling in C++
+  - Bare-Metal C++
+  - Embedded Software Architecture
+  - C++ for IoT Devices
+  - C++ Performance Tuning
+  - Embedded Drivers in C++
+  - C++ and RTOS
+  - C++ in Automotive Systems
+  - Safe C++ for Embedded
+  - Portable Embedded Code in C++
+
+tags:
+  - Embedded Systems
+  - Embedded C++
+  - Real-Time Programming
+  - C++ Firmware
+  - Microcontroller Programming
+  - Memory-Efficient C++
+  - C++ for IoT
+  - C++ Low-Level Programming
+  - RTOS in C++
+  - Embedded Drivers
+  - Safe Embedded Code
+  - Hardware Abstraction in C++
+  - Bare-Metal Programming
+  - Object-Oriented Firmware
+  - Automotive Embedded
+  - Portable C++ Code
+  - C++ Best Practices
+  - Performance Optimization
+  - Interrupts and Timers
+
+---
 import { Question } from '../../Question';
 
 # C++ for Embedded Systems

--- a/docs/mcq/questions/specialized/design-patterns.md
+++ b/docs/mcq/questions/specialized/design-patterns.md
@@ -1,3 +1,50 @@
+---
+id: design-patterns
+title: C++ Design Patterns
+description: |
+  This guide explores common and powerful design patterns implemented in C++, helping you write clean, modular, and scalable software. Learn about creational, structural, and behavioral patterns such as Singleton, Factory, Observer, Strategy, Adapter, and more. Ideal for developers looking to strengthen their architecture and design skills using modern C++ techniques.
+keywords:
+  - C++ Design Patterns
+  - Software Design in C++
+  - Singleton Pattern C++
+  - Factory Pattern C++
+  - Observer Pattern C++
+  - Strategy Pattern C++
+  - Adapter Pattern C++
+  - Creational Patterns C++
+  - Structural Patterns C++
+  - Behavioral Patterns C++
+  - Design Patterns in Programming
+  - Modern C++ Architecture
+  - Reusable Code in C++
+  - C++ Design Principles
+  - SOLID Principles in C++
+  - Clean Code C++
+  - C++ OOP Best Practices
+  - Scalable C++ Applications
+  - C++ Interview Preparation
+
+tags:
+  - Design Patterns
+  - C++ Design Patterns
+  - Singleton Pattern
+  - Factory Pattern
+  - Observer Pattern
+  - Strategy Pattern
+  - Adapter Pattern
+  - Creational Patterns
+  - Structural Patterns
+  - Behavioral Patterns
+  - C++ Architecture
+  - Software Design
+  - Clean Code
+  - Reusable Components
+  - OOP Best Practices
+  - SOLID in C++
+  - Modern C++
+  - C++ Interview Preparation
+
+---
 import { Question } from '../../Question';
 
 # C++ Design Patterns

--- a/docs/mcq/questions/specialized/optimization.md
+++ b/docs/mcq/questions/specialized/optimization.md
@@ -1,3 +1,51 @@
+---
+id: optimization
+title: C++ Optimization Techniques
+description: |
+  Discover essential C++ optimization techniques to write faster, more efficient, and memory-conscious programs. This guide covers compile-time and run-time optimizations, cache-aware programming, memory layout strategies, algorithmic improvements, and compiler-level tuning. Ideal for performance-critical applications in systems programming, gaming, embedded development, and competitive coding.
+keywords:
+  - C++ Optimization
+  - Performance Tuning in C++
+  - C++ Memory Optimization
+  - Cache-Friendly Programming
+  - Compiler Optimizations
+  - Inline Functions in C++
+  - Loop Unrolling in C++
+  - Move Semantics Optimization
+  - STL Optimization Techniques
+  - C++ Efficiency Tips
+  - Time Complexity in C++
+  - C++ Speed Hacks
+  - Performance-Critical C++
+  - C++ Benchmarking
+  - High-Performance C++ Code
+  - Avoiding Memory Leaks
+  - CPU Cache Optimization
+  - Profiling Tools for C++
+  - Modern C++ Optimization
+
+tags:
+  - C++ Optimization
+  - Performance Tuning
+  - Memory Efficiency
+  - Cache Optimization
+  - Compiler Flags
+  - Loop Unrolling
+  - STL Optimization
+  - Move Semantics
+  - Inline Functions
+  - Fast C++ Code
+  - C++ Benchmarking
+  - Time and Space Complexity
+  - Profiling C++ Code
+  - High-Performance C++
+  - Competitive Programming
+  - System-Level C++
+  - Embedded Optimization
+  - Real-Time C++
+  - Optimization Techniques
+---
+
 import { Question } from '../../Question';
 
 # C++ Optimization Techniques

--- a/docs/mcq/questions/specialized/smart-pointers.md
+++ b/docs/mcq/questions/specialized/smart-pointers.md
@@ -1,3 +1,45 @@
+---
+id: smart-pointers
+title: Smart Pointers in C++
+description: |
+  Learn about smart pointers in C++, a modern and safe way to manage dynamic memory. This guide covers `unique_ptr`, `shared_ptr`, and `weak_ptr`, explaining ownership semantics, memory safety, and use-cases to prevent memory leaks and dangling pointers. Ideal for developers transitioning from raw pointers to modern C++ practices.
+keywords:
+  - Smart Pointers in C++
+  - C++ unique_ptr
+  - C++ shared_ptr
+  - C++ weak_ptr
+  - Dynamic Memory Management
+  - Memory Safety in C++
+  - C++ Ownership Semantics
+  - Avoid Memory Leaks in C++
+  - RAII in C++
+  - C++ Resource Management
+  - C++ Best Practices
+  - Modern C++ Memory Handling
+  - Pointer Alternatives
+  - Automatic Memory Cleanup
+  - C++11 Smart Pointers
+  - C++ Reference Counting
+  - Safe Memory Allocation
+
+tags:
+  - Smart Pointers
+  - unique_ptr
+  - shared_ptr
+  - weak_ptr
+  - C++ Memory Management
+  - RAII
+  - Modern C++
+  - C++ Best Practices
+  - Automatic Resource Management
+  - Safe Pointer Usage
+  - Memory Safety
+  - C++11 Features
+  - C++ Resource Ownership
+  - No Memory Leaks
+  - Reference Counting
+
+---
 import { Question } from '../../Question';
 
 # Smart Pointers

--- a/docs/mcq/questions/specialized/specialized.md
+++ b/docs/mcq/questions/specialized/specialized.md
@@ -1,16 +1,48 @@
 ---
 id: specialized
-title: Specialized C++ Learning Guide
-keywords: 
-- C++
-- advanced C++
-- specialized topics
-- C++ optimization
-- algorithms
-- networking
-- game development
----
+title: Learning Specialized C++
+description: "Dive into specialized areas of C++ to master advanced topics beyond the basics. This guide explores template metaprogramming, concurrency and multithreading, low-level systems programming, embedded C++, and modern C++ standards. Perfect for developers aiming to deepen their understanding of how C++ is used in high-performance, real-time, and system-critical applications."
 
+keywords:
+  - Advanced C++ Programming
+  - Specialized C++ Topics
+  - C++ Template Metaprogramming
+  - C++ Multithreading
+  - Low-Level C++ Programming
+  - Embedded C++ Development
+  - C++17 Features
+  - C++20 Features
+  - Real-Time Systems in C++
+  - C++ Systems Programming
+  - C++ for High-Performance Computing
+  - Concurrency in C++
+  - C++ Hardware Access
+  - Modern C++ Techniques
+  - C++ for Specialized Domains
+  - Expert-Level C++ Concepts
+  - C++ Type Traits
+  - STL Internals
+  - Allocator-Aware Programming
+
+tags:
+  - Advanced C++
+  - Template Metaprogramming
+  - Concurrency and Multithreading
+  - Embedded C++
+  - Systems Programming
+  - C++17
+  - C++20
+  - STL Internals
+  - Memory Management
+  - Real-Time C++
+  - Type Traits
+  - Allocators
+  - Low-Level C++
+  - High-Performance C++
+  - Modern C++
+  - Specialized C++
+
+---
 # Learning Specialized C++
 
 Once you've grasped the basics of C++, it's time to dive deeper into more specialized areas that will help you master the language and its powerful features. This guide will walk you through advanced topics, giving you a broad spectrum of C++ knowledge.

--- a/docs/tvm/advanced/custom-pass.md
+++ b/docs/tvm/advanced/custom-pass.md
@@ -1,0 +1,37 @@
+---
+id: custom-pass
+title: Advanced Custom Pass in TVM
+description: |
+  Learn how to implement advanced custom passes in TVM to enhance the optimization of deep learning models. This guide covers how to create your own custom passes, integrate them into the TVM compilation pipeline, and apply them for specialized model optimization. Explore the intricacies of designing custom passes that can manipulate intermediate representations (IR) and improve model performance across different hardware platforms.
+keywords:
+  - TVM
+  - Custom Pass
+  - Advanced Custom Pass
+  - TVM Passes
+  - TVM Optimization
+  - Intermediate Representation (IR)
+  - Custom Compiler Pass
+  - TVM Compiler Pipeline
+  - Model Optimization
+  - Deep Learning Compilation
+  - Pass Design in TVM
+  - Compiler Passes
+  - Performance Tuning
+  - Custom Pass Integration
+  - Advanced Compiler Features
+
+tags:
+  - TVM
+  - Custom Pass
+  - Advanced Pass
+  - TVM Passes
+  - Model Optimization
+  - Intermediate Representation (IR)
+  - Compiler Passes
+  - Performance Tuning
+  - Deep Learning Compiler
+  - TVM Compiler Pipeline
+  - Custom Compiler Pass
+  - TVM Optimization
+  - Compiler Customization
+---

--- a/docs/tvm/advanced/hardware-targets.md
+++ b/docs/tvm/advanced/hardware-targets.md
@@ -1,0 +1,40 @@
+---
+id: hardware-targets
+title: Advanced Hardware Targets in TVM
+description: |
+  Explore the advanced capabilities of TVM when targeting specialized hardware platforms. This guide covers how to leverage TVM's powerful optimization techniques to run deep learning models on various hardware targets, including GPUs, TPUs, FPGAs, and custom accelerators. Learn how to configure TVM to optimize performance for each target and how to take advantage of platform-specific features for maximum efficiency.
+keywords:
+  - TVM
+  - Hardware Targets
+  - Advanced Hardware Targets
+  - GPU Optimization
+  - FPGA Optimization
+  - TPU Optimization
+  - Custom Accelerators
+  - TVM Optimization Techniques
+  - Deep Learning Hardware Acceleration
+  - Hardware-Specific Tuning
+  - TVM Hardware Support
+  - Parallelism in TVM
+  - Performance Optimization
+  - Specialized Hardware
+  - Target-Specific Compilation
+  - TVM Performance Tuning
+
+tags:
+  - TVM
+  - Hardware Targets
+  - Advanced Hardware Targets
+  - GPU Optimization
+  - FPGA Optimization
+  - TPU Optimization
+  - Custom Accelerators
+  - Deep Learning Optimization
+  - Hardware-Specific Tuning
+  - TVM Optimization
+  - Parallelism in TVM
+  - Performance Tuning
+  - Hardware Acceleration
+  - TVM Compilation
+  - Specialized Hardware Targets
+---

--- a/docs/tvm/advanced/meta-scheduler.md
+++ b/docs/tvm/advanced/meta-scheduler.md
@@ -1,0 +1,38 @@
+---
+id: meta-scheduler
+title: Meta Scheduler in TVM
+description: |
+  The Meta Scheduler in TVM is a powerful tool that allows automatic search for the best scheduling strategies for deep learning workloads across different hardware targets. This guide delves into the principles of the Meta Scheduler, its role in optimizing model performance, and how to configure and use it to achieve optimal performance for specific hardware backends. Learn about search space design, cost models, and the integration of Meta Scheduler in TVM's optimization pipeline.
+keywords:
+  - TVM
+  - Meta Scheduler
+  - Scheduling Strategies
+  - TVM Optimization
+  - Hardware Targets
+  - Search Space Design
+  - Cost Models
+  - Deep Learning Scheduling
+  - TVM Scheduler
+  - Model Performance Optimization
+  - Hardware-Specific Scheduling
+  - Performance Tuning
+  - TVM Compilation Pipeline
+  - Deep Learning Compiler
+  - Auto Scheduling
+  - TVM Search Algorithm
+
+tags:
+  - TVM
+  - Meta Scheduler
+  - Scheduling Strategies
+  - TVM Optimization
+  - Hardware Targets
+  - Cost Models
+  - Search Space Design
+  - Performance Optimization
+  - Deep Learning Scheduling
+  - TVM Scheduler
+  - Auto Scheduling
+  - TVM Compilation Pipeline
+  - Performance Tuning
+---

--- a/docs/tvm/basics/autotuning.md
+++ b/docs/tvm/basics/autotuning.md
@@ -1,0 +1,39 @@
+---
+id: autotuning
+title: TVM Autotuning Basics
+description: |
+  TVM is an open-source machine learning compiler stack that provides powerful capabilities for optimizing deep learning workloads across various hardware platforms. This guide introduces the basics of autotuning in TVM, explaining how to improve the performance of your models through automatic search and tuning of optimization parameters, kernel configurations, and scheduling strategies.
+keywords:
+  - TVM
+  - Autotuning
+  - TVM Autotuning
+  - Machine Learning Optimization
+  - Deep Learning Compilation
+  - Optimization Parameters
+  - Kernel Tuning
+  - Scheduling Strategies
+  - Performance Optimization
+  - Hardware Optimization
+  - TVM Compiler
+  - TVM Optimization Techniques
+  - Deep Learning Compiler
+  - Autotuning Methods
+  - ML Workload Optimization
+  - TVM Performance Tuning
+
+tags:
+  - TVM
+  - Autotuning
+  - Machine Learning Optimization
+  - Deep Learning Compilation
+  - Optimization Parameters
+  - Kernel Tuning
+  - Scheduling Strategies
+  - Performance Optimization
+  - Hardware Optimization
+  - Deep Learning Compiler
+  - TVM Autotuning Basics
+  - TVM Performance Tuning
+  - TVM Compiler
+
+---

--- a/docs/tvm/basics/first-model.md
+++ b/docs/tvm/basics/first-model.md
@@ -1,0 +1,39 @@
+---
+id: first-model
+title: TVM First Model Basics
+description: |
+  TVM provides an efficient and flexible machine learning compiler framework that enables you to optimize and run deep learning models on various hardware platforms. This guide covers the basics of getting started with TVM, including how to compile and optimize your first deep learning model using TVM, how to write a simple model, and the steps to compile and deploy it across different backends (CPU, GPU, etc.).
+keywords:
+  - TVM
+  - First Model
+  - TVM Basics
+  - Deep Learning Model
+  - Model Optimization
+  - TVM Compilation
+  - Machine Learning Compiler
+  - Backend Deployment
+  - Hardware Acceleration
+  - TVM First Steps
+  - Compiling Models
+  - Model Deployment
+  - Optimization Techniques
+  - Deep Learning Frameworks
+  - GPU Acceleration
+  - CPU Optimization
+
+tags:
+  - TVM
+  - First Model
+  - TVM Basics
+  - Model Optimization
+  - Machine Learning Compiler
+  - Model Compilation
+  - Backend Deployment
+  - TVM for Deep Learning
+  - GPU Optimization
+  - CPU Optimization
+  - Deep Learning Frameworks
+  - Model Deployment
+  - TVM for Hardware Acceleration
+  - TVM Compilation Steps
+---

--- a/docs/tvm/basics/installation.md
+++ b/docs/tvm/basics/installation.md
@@ -1,0 +1,38 @@
+---
+id: installation
+title: TVM Installation Guide
+description: |
+  This guide walks you through the process of installing TVM, an open-source machine learning compiler stack that allows you to optimize deep learning models for various hardware platforms. Learn how to set up TVM on your system, configure dependencies, and verify the installation. TVM supports installation on various operating systems, including Linux, macOS, and Windows.
+keywords:
+  - TVM
+  - TVM Installation
+  - Machine Learning Compiler
+  - Deep Learning Optimization
+  - Install TVM
+  - Setup TVM
+  - TVM Dependencies
+  - TVM Setup Guide
+  - TVM on Linux
+  - TVM on macOS
+  - TVM on Windows
+  - TVM Environment Setup
+  - Installation Steps
+  - TVM Compiler Installation
+  - Deep Learning Compiler Installation
+  - TVM Compilation
+
+tags:
+  - TVM
+  - TVM Installation
+  - Machine Learning Compiler
+  - Deep Learning Optimization
+  - TVM Setup
+  - Install TVM
+  - TVM Dependencies
+  - Linux Installation
+  - macOS Installation
+  - Windows Installation
+  - TVM Environment Setup
+  - Installation Guide
+  - Compiler Setup
+---

--- a/docs/tvm/deployment/cloud.md
+++ b/docs/tvm/deployment/cloud.md
@@ -1,0 +1,40 @@
+---
+id: cloud
+title: TVM Deployment on Cloud
+description: |
+  Learn how to deploy deep learning models optimized using TVM on cloud platforms for scalable and efficient inference. This guide explores how to configure TVM for cloud environments, including popular cloud services such as AWS, Google Cloud, and Microsoft Azure. Discover the benefits of cloud deployment, such as elastic scaling, high availability, and cost efficiency, and how to take advantage of cloud-based GPUs and specialized hardware to accelerate your model inference.
+keywords:
+  - TVM
+  - Cloud Deployment
+  - TVM on Cloud
+  - Cloud Inference
+  - Scalable Deployment
+  - Cloud Services
+  - AWS
+  - Google Cloud
+  - Microsoft Azure
+  - Cloud GPUs
+  - Cloud Inference Optimization
+  - Model Deployment
+  - TVM Optimization
+  - Cloud-based Hardware
+  - Deep Learning on Cloud
+  - Elastic Scaling
+
+tags:
+  - TVM
+  - Cloud Deployment
+  - Cloud Inference
+  - Cloud GPUs
+  - TVM on Cloud
+  - AWS
+  - Google Cloud
+  - Microsoft Azure
+  - Scalable Deployment
+  - TVM Optimization
+  - Cloud-based Hardware
+  - Model Deployment
+  - Deep Learning on Cloud
+  - Cloud Inference Optimization
+  - Elastic Scaling
+---

--- a/docs/tvm/deployment/edge.md
+++ b/docs/tvm/deployment/edge.md
@@ -1,0 +1,39 @@
+---
+id: edge
+title: TVM Deployment on Edge Devices
+description: |
+  Learn how to deploy deep learning models optimized using TVM on edge devices for efficient and low-latency inference. This guide covers the steps to configure TVM for edge device deployment, including platforms like Raspberry Pi, NVIDIA Jetson, and mobile devices. Understand how TVM optimizes models for resource-constrained devices, ensuring performance, efficiency, and scalability at the edge.
+keywords:
+  - TVM
+  - Edge Deployment
+  - TVM on Edge Devices
+  - Edge Inference
+  - Low Latency Inference
+  - Resource-Constrained Devices
+  - Edge AI
+  - Edge Computing
+  - Raspberry Pi
+  - NVIDIA Jetson
+  - Mobile Edge Devices
+  - TVM Optimization
+  - Edge Device Optimization
+  - Edge Hardware
+  - TVM Deployment at Edge
+  - Efficient Edge Inference
+
+tags:
+  - TVM
+  - Edge Deployment
+  - Edge Devices
+  - TVM on Edge
+  - Low Latency Inference
+  - Edge AI
+  - Raspberry Pi
+  - NVIDIA Jetson
+  - Mobile Edge Devices
+  - Resource-Constrained Devices
+  - TVM Optimization
+  - Edge Computing
+  - Edge Inference
+  - TVM Edge Deployment
+---

--- a/docs/tvm/deployment/runtime.md
+++ b/docs/tvm/deployment/runtime.md
@@ -1,0 +1,39 @@
+---
+id: runtime
+title: TVM Runtime Deployment
+description: |
+  This guide covers the process of deploying deep learning models optimized with TVM to various runtime environments. Learn how to integrate TVM’s runtime for executing models across different hardware platforms, including CPUs, GPUs, and specialized accelerators. Understand how to configure TVM's runtime API for efficient inference and optimize it for production environments to handle real-time, low-latency inference demands.
+keywords:
+  - TVM
+  - Runtime Deployment
+  - TVM Runtime
+  - Model Inference
+  - Production Deployment
+  - TVM on Hardware
+  - Low Latency Inference
+  - GPU Inference
+  - CPU Inference
+  - Specialized Accelerators
+  - TVM Runtime API
+  - Real-Time Inference
+  - Inference Optimization
+  - TVM Deployment
+  - Efficient Model Execution
+
+tags:
+  - TVM
+  - Runtime Deployment
+  - TVM Runtime
+  - Model Inference
+  - Production Deployment
+  - Hardware Deployment
+  - GPU Inference
+  - CPU Inference
+  - Specialized Accelerators
+  - Low Latency Inference
+  - TVM Runtime API
+  - Real-Time Inference
+  - Inference Optimization
+  - TVM Deployment
+
+---

--- a/docs/tvm/intermediate/graph-optimizations.md
+++ b/docs/tvm/intermediate/graph-optimizations.md
@@ -1,0 +1,38 @@
+---
+id: graph-optimizations
+title: Graph Optimization in TVM
+description: |
+  Graph optimization in TVM focuses on transforming and optimizing computational graphs for deep learning models to achieve faster execution and lower resource usage. This guide covers techniques such as operator fusion, constant folding, memory optimization, and graph partitioning that can be applied to optimize models before execution. Learn how TVM performs automatic graph optimization and how to fine-tune it for better performance on various hardware backends.
+keywords:
+  - TVM
+  - Graph Optimization
+  - TVM Optimization
+  - Computational Graph
+  - Operator Fusion
+  - Constant Folding
+  - Memory Optimization
+  - Graph Partitioning
+  - Deep Learning Graph Optimization
+  - TVM Compiler
+  - TVM Transformation
+  - Performance Optimization
+  - Model Optimization
+  - Hardware Optimization
+  - TVM Backend Optimization
+
+tags:
+  - TVM
+  - Graph Optimization
+  - Model Optimization
+  - Computational Graph
+  - Operator Fusion
+  - Constant Folding
+  - Memory Optimization
+  - Graph Partitioning
+  - Performance Tuning
+  - TVM Compiler
+  - TVM Optimization Techniques
+  - Hardware-Specific Optimization
+  - Deep Learning Optimization
+  - TVM Backend Optimization
+---

--- a/docs/tvm/intermediate/relay.md
+++ b/docs/tvm/intermediate/relay.md
@@ -1,0 +1,37 @@
+---
+id: relay
+title: Relay in TVM
+description: |
+  Relay is an intermediate representation (IR) in TVM, designed to bridge the gap between high-level deep learning models and low-level hardware-specific code. This guide explores how Relay works in TVM, its role in optimization, and how it enables advanced optimizations like operator fusion, graph rewriting, and target-specific code generation. Learn how to leverage Relay for efficient model optimization and deployment across different hardware backends.
+keywords:
+  - TVM
+  - Relay
+  - Intermediate Representation (IR)
+  - TVM Optimization
+  - Operator Fusion
+  - Graph Rewriting
+  - Model Optimization
+  - Target-Specific Code Generation
+  - Deep Learning Compilation
+  - Relay IR
+  - TVM Compiler
+  - Deep Learning Optimization
+  - TVM Backend
+  - TVM Intermediate Representation
+  - Model Deployment
+
+tags:
+  - TVM
+  - Relay
+  - Intermediate Representation (IR)
+  - TVM Optimization
+  - Deep Learning Compilation
+  - Operator Fusion
+  - Graph Rewriting
+  - Model Optimization
+  - Target-Specific Code Generation
+  - TVM Compiler
+  - TVM Backend Optimization
+  - Relay IR
+  - Model Deployment
+---

--- a/docs/tvm/intermediate/schedule-tuning.md
+++ b/docs/tvm/intermediate/schedule-tuning.md
@@ -1,0 +1,36 @@
+---
+id: schedule-tuning
+title: Schedule Tuning in TVM
+description: |
+  Schedule tuning in TVM involves optimizing the execution schedule of computational operations to improve performance on specific hardware targets. This guide covers the principles of schedule tuning in TVM, including techniques for optimizing loop ordering, parallelization, and memory usage. Learn how to fine-tune your schedules to achieve the best performance for deep learning models across various hardware backends such as CPUs, GPUs, and specialized accelerators.
+keywords:
+  - TVM
+  - Schedule Tuning
+  - Performance Optimization
+  - TVM Scheduling
+  - Deep Learning Optimization
+  - Hardware-Specific Optimization
+  - Loop Optimization
+  - Parallelization
+  - Memory Usage Optimization
+  - TVM Compiler
+  - Hardware Targets
+  - Computational Scheduling
+  - Model Performance Tuning
+  - TVM Optimization
+
+tags:
+  - TVM
+  - Schedule Tuning
+  - Performance Optimization
+  - TVM Scheduling
+  - Loop Optimization
+  - Parallelization
+  - Memory Optimization
+  - Hardware-Specific Optimization
+  - Deep Learning Optimization
+  - TVM Compiler
+  - TVM Performance Tuning
+  - Hardware Targets
+  - Computational Scheduling
+---

--- a/sidebars.js
+++ b/sidebars.js
@@ -7,13 +7,13 @@ const sidebars = {
       label: 'Compilers',
       collapsed: true,
       items: [
-        'compilers/compiler',                 // Overview of compilers
-        'compilers/CPU/index',                // Tutorials specific to CPU compilers
-        'compilers/GPU/index',                // Tutorials specific to GPU compilers
-        'compilers/back_end/index',           // Backend concepts and tutorials
-        'compilers/flag/index',               // Compiler flags and optimizations
-        'compilers/front_end/index',          // Frontend concepts and tutorials
-        'compilers/other_arch/index',         // Tutorials for other architectures
+        'compilers/Compiler',                 // Overview of compilers
+        'compilers/CPU/cpu-compilers',                // Tutorials specific to CPU compilers
+        'compilers/GPU/gpu-compilers',                // Tutorials specific to GPU compilers
+        'compilers/back_end/introduction-to-backend-compilers',           // Backend concepts and tutorials
+        'compilers/flag/compiler-flags',               // Compiler flags and optimizations
+        'compilers/front_end/compiler-frontend',          // Frontend concepts and tutorials
+        'compilers/other_arch/other-architectures',         // Tutorials for other architectures
         'compilers/gcc_vs_llvm',             // Tutorials for gcc vs llvm
         'compilers/clang-c-vs-cpp-compilation', //Tutorials for clang c vs cpp
         'compilers/Verification_Vs_Validation' // Tutorial for the verification vs validation
@@ -29,7 +29,7 @@ const sidebars = {
       collapsed: true,
       items: [
         'gpu/introduction',                   // Introduction to GPU concepts
-        'gpu/optimizations',                  // GPU-specific optimization techniques
+        'gpu/OptimizationOfGPU',                  // GPU-specific optimization techniques
         'gpu/evolution-of-parallel-programming',
         'gpu/CPU_Vs_GPU'
       ],
@@ -117,14 +117,14 @@ const sidebars = {
           type: 'category',
           label: 'Basic',
           items: [
-            'c++/c++_main_file',               // Basic C++ introduction
+            'c++/CppTutorial',               // Basic C++ introduction
           ],
         },
         {
           type: 'category',
           label: 'Intermediate',
           items: [
-            'c++/intermediate/index',          // Intermediate C++ concepts
+            'c++/intermediate/IntermediateCpp',          // Intermediate C++ concepts
           ],
         },
         {
@@ -138,7 +138,7 @@ const sidebars = {
           type: 'category',
           label: 'Standard',
           items: [
-            'c++/standard/index',             // C++ Standard Library topics
+            'c++/standard/intro',             // C++ Standard Library topics
           ],
         },
       ],
@@ -234,7 +234,7 @@ const sidebars = {
             'mcq/questions/intermediate/file-handling',
             'mcq/questions/intermediate/friend-functions',
             'mcq/questions/intermediate/inheritance',
-            'mcq/questions/intermediate/intermediate',
+            'mcq/questions/intermediate/getting-started-with-oops-concept',
             'mcq/questions/intermediate/memory-management',
             'mcq/questions/intermediate/oop',
             'mcq/questions/intermediate/operator-overloading',
@@ -245,8 +245,8 @@ const sidebars = {
           type: 'category',
           label: 'Advanced MCQs',
           items: [
-            'mcq/questions/advanced/concurrency',
-            'mcq/questions/advanced/cpp-features',
+            'mcq/questions/advanced/concurrency-and-synchronization',
+            'mcq/questions/advanced/cpp-features-11-14-17-20',
             'mcq/questions/advanced/exception-handling',
             'mcq/questions/advanced/lambdas',
             'mcq/questions/advanced/move-semantics',
@@ -280,10 +280,11 @@ const sidebars = {
             'mcq/interview_question/basic/arrays-strings',
             'mcq/interview_question/basic/io-operations',
             'mcq/interview_question/basic/pointers-references',
-            'mcq/interview_question/intermediate/classes-object',
-            'mcq/interview_question/intermediate/constructors-destructors',
+            'mcq/interview_question/intermediate/ClassesObjects',
+            'mcq/interview_question/intermediate/CppInterviewQuestionsConstructorsDestructors',
+            'mcq/interview_question/intermediate/EssentialCppInterviewQuestionsInheritancePolymorphism',
             'mcq/interview_question/intermediate/oop',
-            'mcq/interview_question/intermediate/exception-handling',
+            'mcq/interview_question/intermediate/CppInterviewQuestionsExceptionHandling',
             'mcq/interview_question/intermediate/memory-management',
             'mcq/interview_question/intermediate/operator-overloading',
 


### PR DESCRIPTION
# Pull Request: Add Metadata to Documentation Markdown Files

## Summary

This pull request adds standardized metadata blocks (YAML frontmatter) to the top of relevant Markdown (`.md`) documentation files. The metadata includes `title`, `description`, `keywords`, and `tags` to enhance the structure, SEO, and integration with static site generators.

## Changes Introduced

- Added YAML frontmatter to all applicable Markdown files.
- Each metadata block includes:
  - `title`: A descriptive and concise page title.
  - `description`: A one-paragraph summary for SEO and preview purposes.
  - `keywords`: A list of related keywords for indexing.
  - `tags`: Topical labels for internal grouping and categorization.

## Purpose

- Improve search engine optimization (SEO).
- Provide semantic clarity and content summaries.
- Enhance compatibility with tools like Docusaurus, Hugo, and other static site generators.
- Improve content discoverability and maintainability.

## Example

```yaml
---
title: "Know Your Compiler"
description: "Discover the inner workings of compilers in this insightful guide. From basic concepts to advanced features..."
keywords:
  - Compiler
  - Source Code
  - Compiler Design
tags:
  - Software Development
  - Compiler Technology
---
